### PR TITLE
Solution for issue #14, reduced the cut-off/ignore time limit

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -35,7 +35,7 @@ unsigned int RCSwitch::nReceivedBitlength = 0;
 unsigned int RCSwitch::nReceivedDelay = 0;
 unsigned int RCSwitch::nReceivedProtocol = 0;
 int RCSwitch::nReceiveTolerance = 60;
-unsigned int RCSwitch::nSeparationLimit = 4600;
+const unsigned int RCSwitch::nSeparationLimit = 4600;
 // separationLimit: minimum microseconds between received codes, closer codes are ignored.
 // according to discussion on issue #14 it might be more suitable to set the separation
 // limit to the same time as the 'low' part of the sync signal for the current protocol.

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -35,6 +35,10 @@ unsigned int RCSwitch::nReceivedBitlength = 0;
 unsigned int RCSwitch::nReceivedDelay = 0;
 unsigned int RCSwitch::nReceivedProtocol = 0;
 int RCSwitch::nReceiveTolerance = 60;
+unsigned int RCSwitch::nSeparationLimit = 4600;
+// separationLimit: minimum microseconds between received codes, closer codes are ignored.
+// according to discussion on issue #14 it might be more suitable to set the separation
+// limit to the same time as the 'low' part of the sync signal for the current protocol.
 #endif
 unsigned int RCSwitch::timings[RCSWITCH_MAX_CHANGES];
 
@@ -362,7 +366,7 @@ char* RCSwitch::getCodeWordC(char sFamily, int nGroup, int nDevice, boolean bSta
  *
  * @param sGroup        Name of the switch group (A..D, resp. a..d) 
  * @param nDevice       Number of the switch itself (1..3)
- * @param bStatus       Wether to switch on (true) or off (false)
+ * @param bStatus       Whether to switch on (true) or off (false)
  *
  * @return char[13]
  */
@@ -788,7 +792,7 @@ void RCSwitch::handleInterrupt() {
   long time = micros();
   duration = time - lastTime;
  
-  if (duration > 5000 && duration > RCSwitch::timings[0] - 200 && duration < RCSwitch::timings[0] + 200) {
+  if (duration > RCSwitch::nSeparationLimit && duration > RCSwitch::timings[0] - 200 && duration < RCSwitch::timings[0] + 200) {
     repeatCount++;
     changeCount--;
     if (repeatCount == 2) {
@@ -802,7 +806,7 @@ void RCSwitch::handleInterrupt() {
       repeatCount = 0;
     }
     changeCount = 0;
-  } else if (duration > 5000) {
+  } else if (duration > RCSwitch::nSeparationLimit) {
     changeCount = 0;
   }
  

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -132,6 +132,7 @@ class RCSwitch {
     static unsigned int nReceivedBitlength;
     static unsigned int nReceivedDelay;
     static unsigned int nReceivedProtocol;
+    static unsigned int nSeparationLimit;
     #endif
     /* 
      * timings[0] contains sync timing, followed by a number of bits

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -132,7 +132,7 @@ class RCSwitch {
     static unsigned int nReceivedBitlength;
     static unsigned int nReceivedDelay;
     static unsigned int nReceivedProtocol;
-    static unsigned int nSeparationLimit;
+    const static unsigned int nSeparationLimit;
     #endif
     /* 
      * timings[0] contains sync timing, followed by a number of bits


### PR DESCRIPTION
This reduces the "time separation limit" from 5000 microseconds (us) to 4600 us since some devices have less than 5000 us between transmitted codes. See issue #14 for additional info.