### PR TITLE
Adds compilation support for Raspberry Pi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Mac stuff
+.DS_Store
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -596,7 +596,7 @@ void RCSwitch::enableReceive() {
  * Disable receiving data
  */
 void RCSwitch::disableReceive() {
-#if not defined(RaspberryPi)
+#if not defined(RaspberryPi) // Arduino
   detachInterrupt(this->nReceiverInterrupt);
 #endif // For Raspberry Pi (wiringPi) you can't unregister the ISR
   this->nReceiverInterrupt = -1;

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -31,6 +31,25 @@
 
 #include "RCSwitch.h"
 
+/* Format for protocol definitions:
+ * {pulselength, Sync bit, "0" bit, "1" bit}
+ * 
+ * pulselength: pulse length in microseconds, e.g. 350
+ * Sync bit: {1, 31} means 1 high pulse and 31 low pulses
+ *     (perceived as a 31*pulselength long pulse, total length of sync bit is
+ *     32*pulselength microseconds), i.e:
+ *      _
+ *     | |_______________________________ (don't count the vertical bars)
+ * "0" bit: waveform for a data bit of value "0", {1, 3} means 1 high pulse
+ *     and 3 low pulses, total length (1+3)*pulselength, i.e:
+ *      _
+ *     | |___
+ * "1" bit: waveform for a data bit of value "1", e.g. {3,1}:
+ *      ___
+ *     |   |_
+ *
+ * These are combined to form Tri-State bits when sending or receiving codes.
+ */
 static const RCSwitch::Protocol PROGMEM proto[] = {
     { 350, {  1, 31 }, {  1,  3 }, {  3,  1 } },    // protocol 1
     { 650, {  1, 10 }, {  1,  2 }, {  2,  1 } },    // protocol 2

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -9,6 +9,7 @@
   - Dominik Fischer / dom_fischer(at)web(dot)de
   - Frank Oltmanns / <first name>.<last name>(at)gmail(dot)com
   - Andreas Steinel / A.<lastname>(at)gmail(dot)com
+  - Robert ter Vehn / <first name>.<last name>(at)gmail(dot)com
   
   Project home: http://code.google.com/p/rc-switch/
 
@@ -620,7 +621,11 @@ void RCSwitch::enableReceive() {
   if (this->nReceiverInterrupt != -1) {
     RCSwitch::nReceivedValue = NULL;
     RCSwitch::nReceivedBitlength = NULL;
+#if defined(RaspberryPi) // Raspberry Pi
+    wiringPiISR(this->nReceiverInterrupt, INT_EDGE_BOTH, &handleInterrupt);
+#else // Arduino
     attachInterrupt(this->nReceiverInterrupt, handleInterrupt, CHANGE);
+#endif
   }
 }
 
@@ -628,7 +633,9 @@ void RCSwitch::enableReceive() {
  * Disable receiving data
  */
 void RCSwitch::disableReceive() {
+#if not defined(RaspberryPi)
   detachInterrupt(this->nReceiverInterrupt);
+#endif // For Raspberry Pi (wiringPi) you can't unregister the ISR
   this->nReceiverInterrupt = -1;
 }
 

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -33,7 +33,7 @@
 #if defined(ARDUINO) && ARDUINO >= 100
     #include "Arduino.h"
 #elif defined(ENERGIA) // LaunchPad, FraunchPad and StellarPad specific
-    #include "Energia.h"	
+    #include "Energia.h"
 #elif defined(RPI) // Raspberry Pi
     #define RaspberryPi
     // PROGMEM och _P functions are for AVR based microprocessors,

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -37,7 +37,7 @@
 #elif defined(RPI) // Raspberry Pi
     #define RaspberryPi
     // PROGMEM och _P functions are for AVR based microprocessors,
-	// so we must normalize these for the ARM processor:
+    // so we must normalize these for the ARM processor:
     #define PROGMEM
     #define memcpy_P(dest, src, num) memcpy((dest), (src), (num))
     // Include libraries for RPi:
@@ -97,7 +97,7 @@ class RCSwitch {
     void disableReceive();
     bool available();
     void resetAvailable();
-	
+
     unsigned long getReceivedValue();
     unsigned int getReceivedBitlength();
     unsigned int getReceivedDelay();

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -32,6 +32,23 @@
     #include "Arduino.h"
 #elif defined(ENERGIA) // LaunchPad, FraunchPad and StellarPad specific
     #include "Energia.h"	
+#elif defined(RPI) // Raspberry Pi
+    #define RaspberryPi
+    #include <wiringPi.h>
+    #include <stdint.h>
+    #define NULL 0
+    #define CHANGE 1
+#ifdef __cplusplus
+extern "C"{
+#endif
+typedef uint8_t boolean;
+typedef uint8_t byte;
+
+#if !defined(NULL)
+#endif
+#ifdef __cplusplus
+}
+#endif // Last line inside Raspberry Pi block
 #else
     #include "WProgram.h"
 #endif

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -47,15 +47,17 @@
     #include <wiringPi.h>
     #include <stdint.h>
     #define CHANGE 1
-#ifdef __cplusplus
-extern "C"{
-#endif
-typedef uint8_t boolean;
-typedef uint8_t byte;
-
-#ifdef __cplusplus
-}
-#endif // Last line within Raspberry Pi block
+    // The following typedefs are needed to be able to compile RCSwitch.cpp
+    // with the RPi C++ compiler (g++)
+    #ifdef __cplusplus
+        extern "C"{
+    #endif
+        typedef uint8_t boolean;
+        typedef uint8_t byte;
+    #ifdef __cplusplus
+    }
+    #endif
+    // Last line within Raspberry Pi block
 #else
     #include "WProgram.h"
 #endif

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -36,9 +36,16 @@
     #include "Energia.h"	
 #elif defined(RPI) // Raspberry Pi
     #define RaspberryPi
+    // PROGMEM och _P functions are for AVR based microprocessors,
+	// so we must normalize these for the ARM processor:
+    #define PROGMEM
+    #define memcpy_P(dest, src, num) memcpy((dest), (src), (num))
+    // Include libraries for RPi:
+    #include <string.h> /* memcpy */
+    #include <stdlib.h> /* abs */
+    #include <stddef.h> /* NULL */
     #include <wiringPi.h>
     #include <stdint.h>
-    #define NULL 0
     #define CHANGE 1
 #ifdef __cplusplus
 extern "C"{
@@ -46,8 +53,6 @@ extern "C"{
 typedef uint8_t boolean;
 typedef uint8_t byte;
 
-#if !defined(NULL)
-#endif
 #ifdef __cplusplus
 }
 #endif // Last line within Raspberry Pi block

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rc-switch
-Use your Arduino to operate remote radio controlled devices
+Use your Arduino or Raspberry Pi to operate remote radio controlled devices
 
 ##Download
 https://github.com/sui77/rc-switch/releases/latest
@@ -7,12 +7,15 @@ https://github.com/sui77/rc-switch/releases/latest
 ##Info
 ###Send RC codes
 
-Use your Arduino to operate remote radio controlled devices. This will most likely work with all popular low cost power outlet sockets.
+Use your Arduino or Raspberry Pi to operate remote radio controlled devices. This will most likely work with all popular low cost power outlet sockets. If yours doesn't work, you might need to adjust the pulse length for some to work.
 
-All you need is a Arduino, a 315/433MHz AM transmitter  and one or more devices with a SC5262 / SC5272, HX2262 / HX2272, PT2262 / PT2272, EV1527, RT1527, FP1527 or HS1527 chipset. Also supports Intertechno outlets.
+All you need is a Arduino or Raspberry Pi, a 315/433MHz AM transmitter  and one or more devices with a SC5262 / SC5272, HX2262 / HX2272, PT2262 / PT2272, EV1527, RT1527, FP1527 or HS1527 chipset. Also supports Intertechno outlets.
 
 ###Receive and decode RC codes
 
 Find out what codes your remote is sending. Use your remote to control your Arduino.
 
 All you need is a Arduino, a 315/433MHz AM receiver (altough there is no instruction yet, yes it is possible to hack an existing device) and a remote hand set.
+
+For Raspberry Pi, clone the https://github.com/ninjablocks/433Utils project to compile a sniffer tool and transmission commands.
+


### PR DESCRIPTION
A couple of years ago the https://github.com/ninjablocks/433Utils project copied files from rc-switch. Since then rc-switch has been updated and supports more remotes whereas the 433Utils copy has remained more or less unchanged.

To prevent this from keep happening, and to "gather forces" for development, I've incorporated rc-switch as a git submodule (not yet "pull requested"). For this to work the rc-switch project need some minor adjustments to support Raspberry Pi.

I've build and tested this on a Raspberry Pi and confirmed that it works. I don't have an Arduino so I can't test that.