### PR TITLE
Protocols as structs

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -662,106 +662,108 @@ unsigned int* RCSwitch::getReceivedRawdata() {
     return RCSwitch::timings;
 }
 
+/* helper function for the various receiveProtocol methods */
+static inline unsigned long diff(long A, long B) {
+    return abs(A - B);
+}
+
 /**
  *
  */
-bool RCSwitch::receiveProtocol1(unsigned int changeCount){
-    
-      unsigned long code = 0;
-      unsigned long delay = RCSwitch::timings[0] / PROTOCOL1_SYNC_FACTOR;
-      unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance / 100;    
+bool RCSwitch::receiveProtocol1(unsigned int changeCount) {
 
-      for (unsigned int i = 1; i<changeCount ; i=i+2) {
-      
-          if (RCSwitch::timings[i] > delay-delayTolerance && RCSwitch::timings[i] < delay+delayTolerance && RCSwitch::timings[i+1] > delay*3-delayTolerance && RCSwitch::timings[i+1] < delay*3+delayTolerance) {
-            code = code << 1;
-          } else if (RCSwitch::timings[i] > delay*3-delayTolerance && RCSwitch::timings[i] < delay*3+delayTolerance && RCSwitch::timings[i+1] > delay-delayTolerance && RCSwitch::timings[i+1] < delay+delayTolerance) {
-            code+=1;
-            code = code << 1;
-          } else {
+    unsigned long code = 0;
+    const unsigned long delay = RCSwitch::timings[0] / PROTOCOL1_SYNC_FACTOR;
+    const unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance / 100;
+
+    for (unsigned int i = 1; i < changeCount; i += 2) {
+        code <<= 1;
+        if (diff(RCSwitch::timings[i], delay) < delayTolerance &&
+            diff(RCSwitch::timings[i + 1], delay * 3) < delayTolerance) {
+            // zero
+        } else if (diff(RCSwitch::timings[i], delay * 3) < delayTolerance &&
+                   diff(RCSwitch::timings[i + 1], delay) < delayTolerance) {
+            // one
+            code |= 1;
+        } else {
             // Failed
-            i = changeCount;
-            code = 0;
-          }
-      }      
-      code = code >> 1;
-    if (changeCount > 6) {    // ignore < 4bit values as there are no devices sending 4bit values => noise
-      RCSwitch::nReceivedValue = code;
-      RCSwitch::nReceivedBitlength = changeCount / 2;
-      RCSwitch::nReceivedDelay = delay;
-      RCSwitch::nReceivedProtocol = 1;
+            return false;
+        }
     }
 
-    return code != 0;
+    if (changeCount > 6) {    // ignore < 4bit values as there are no devices sending 4bit values => noise
+        RCSwitch::nReceivedValue = code;
+        RCSwitch::nReceivedBitlength = changeCount / 2;
+        RCSwitch::nReceivedDelay = delay;
+        RCSwitch::nReceivedProtocol = 1;
+    }
+
+    return true;
 }
 
-bool RCSwitch::receiveProtocol2(unsigned int changeCount){
-    
-      unsigned long code = 0;
-      unsigned long delay = RCSwitch::timings[0] / PROTOCOL2_SYNC_FACTOR;
-      unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance / 100;    
+bool RCSwitch::receiveProtocol2(unsigned int changeCount) {
 
-      for (unsigned int i = 1; i<changeCount ; i=i+2) {
-      
-          if (RCSwitch::timings[i] > delay-delayTolerance && RCSwitch::timings[i] < delay+delayTolerance && RCSwitch::timings[i+1] > delay*2-delayTolerance && RCSwitch::timings[i+1] < delay*2+delayTolerance) {
-            code = code << 1;
-          } else if (RCSwitch::timings[i] > delay*2-delayTolerance && RCSwitch::timings[i] < delay*2+delayTolerance && RCSwitch::timings[i+1] > delay-delayTolerance && RCSwitch::timings[i+1] < delay+delayTolerance) {
-            code+=1;
-            code = code << 1;
-          } else {
+    unsigned long code = 0;
+    const unsigned long delay = RCSwitch::timings[0] / PROTOCOL2_SYNC_FACTOR;
+    const unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance / 100;
+
+    for (unsigned int i = 1; i < changeCount; i += 2) {
+        code <<= 1;
+        if (diff(RCSwitch::timings[i], delay) < delayTolerance &&
+            diff(RCSwitch::timings[i + 1], delay * 2) < delayTolerance) {
+            // zero
+        } else if (diff(RCSwitch::timings[i], delay * 2) < delayTolerance &&
+                   diff(RCSwitch::timings[i + 1], delay) < delayTolerance) {
+            // one
+            code |= 1;
+        } else {
             // Failed
-            i = changeCount;
-            code = 0;
-          }
-      }      
-      code = code >> 1;
-    if (changeCount > 6) {    // ignore < 4bit values as there are no devices sending 4bit values => noise
-      RCSwitch::nReceivedValue = code;
-      RCSwitch::nReceivedBitlength = changeCount / 2;
-      RCSwitch::nReceivedDelay = delay;
-      RCSwitch::nReceivedProtocol = 2;
+            return false;
+        }
     }
 
-    return code != 0;
+    if (changeCount > 6) {    // ignore < 4bit values as there are no devices sending 4bit values => noise
+        RCSwitch::nReceivedValue = code;
+        RCSwitch::nReceivedBitlength = changeCount / 2;
+        RCSwitch::nReceivedDelay = delay;
+        RCSwitch::nReceivedProtocol = 2;
+    }
+
+    return true;
 }
 
 /** Protocol 3 is used by BL35P02.
  *
  */
-bool RCSwitch::receiveProtocol3(unsigned int changeCount){
-    
-      unsigned long code = 0;
-      unsigned long delay = RCSwitch::timings[0] / PROTOCOL3_SYNC_FACTOR;
-      unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance / 100;    
+bool RCSwitch::receiveProtocol3(unsigned int changeCount) {
 
-      for (unsigned int i = 1; i<changeCount ; i=i+2) {
-      
-          if  (RCSwitch::timings[i]   > delay*PROTOCOL3_0_HIGH_CYCLES - delayTolerance
-            && RCSwitch::timings[i]   < delay*PROTOCOL3_0_HIGH_CYCLES + delayTolerance
-            && RCSwitch::timings[i+1] > delay*PROTOCOL3_0_LOW_CYCLES  - delayTolerance
-            && RCSwitch::timings[i+1] < delay*PROTOCOL3_0_LOW_CYCLES  + delayTolerance) {
-            code = code << 1;
-          } else if (RCSwitch::timings[i]   > delay*PROTOCOL3_1_HIGH_CYCLES - delayTolerance
-                  && RCSwitch::timings[i]   < delay*PROTOCOL3_1_HIGH_CYCLES + delayTolerance
-                  && RCSwitch::timings[i+1] > delay*PROTOCOL3_1_LOW_CYCLES  - delayTolerance
-                  && RCSwitch::timings[i+1] < delay*PROTOCOL3_1_LOW_CYCLES  + delayTolerance) {
-            code+=1;
-            code = code << 1;
-          } else {
+    unsigned long code = 0;
+    const unsigned long delay = RCSwitch::timings[0] / PROTOCOL3_SYNC_FACTOR;
+    const unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance / 100;
+
+    for (unsigned int i = 1; i < changeCount; i += 2) {
+        code <<= 1;
+        if (diff(RCSwitch::timings[i], delay * PROTOCOL3_0_HIGH_CYCLES) < delayTolerance &&
+            diff(RCSwitch::timings[i + 1], delay * PROTOCOL3_0_LOW_CYCLES) < delayTolerance) {
+            // zero
+        } else if (diff(RCSwitch::timings[i], delay * PROTOCOL3_1_HIGH_CYCLES) < delayTolerance &&
+                   diff(RCSwitch::timings[i + 1], delay * PROTOCOL3_1_LOW_CYCLES) < delayTolerance) {
+            // one
+            code |= 1;
+        } else {
             // Failed
-            i = changeCount;
-            code = 0;
-          }
-      }      
-      code = code >> 1;
-      if (changeCount > 6) {    // ignore < 4bit values as there are no devices sending 4bit values => noise
+            return false;
+        }
+    }
+
+    if (changeCount > 6) {    // ignore < 4bit values as there are no devices sending 4bit values => noise
         RCSwitch::nReceivedValue = code;
         RCSwitch::nReceivedBitlength = changeCount / 2;
         RCSwitch::nReceivedDelay = delay;
         RCSwitch::nReceivedProtocol = 3;
-      }
+    }
 
-    return code != 0;
+    return true;
 }
 
 void RCSwitch::handleInterrupt() {
@@ -775,7 +777,7 @@ void RCSwitch::handleInterrupt() {
   long time = micros();
   duration = time - lastTime;
  
-  if (duration > RCSwitch::nSeparationLimit && duration > RCSwitch::timings[0] - 200 && duration < RCSwitch::timings[0] + 200) {
+  if (duration > RCSwitch::nSeparationLimit && diff(duration, RCSwitch::timings[0]) < 200) {
     repeatCount++;
     changeCount--;
     if (repeatCount == 2) {

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -709,23 +709,15 @@ void RCSwitch::handleInterrupt() {
 /**
   * Turns a decimal value to its binary representation
   */
-char* RCSwitch::dec2binWcharfill(unsigned long Dec, unsigned int bitLength, char fill){
-  static char bin[64];
-  unsigned int i=0;
+char* RCSwitch::dec2binWcharfill(unsigned long dec, unsigned int bitLength, char fill) {
+  static char bin[32];
 
-  while (Dec > 0) {
-    bin[32+i++] = ((Dec & 1) > 0) ? '1' : fill;
-    Dec = Dec >> 1;
-  }
-
-  for (unsigned int j = 0; j< bitLength; j++) {
-    if (j >= bitLength - i) {
-      bin[j] = bin[ 31 + i - (j - (bitLength - i)) ];
-    }else {
-      bin[j] = fill;
-    }
-  }
   bin[bitLength] = '\0';
-  
+  while (bitLength > 0) {
+    bitLength--;
+    bin[bitLength] = (dec & 1) ? '1' : fill;
+    dec >>= 1;
+  }
+
   return bin;
 }

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -302,23 +302,15 @@ char* RCSwitch::getCodeWordA(const char* sGroup, const char* sDevice, boolean bO
     int i = 0;
     int j = 0;
     
-    for (i=0; i < 5; i++) {
-        if (sGroup[i] == '0') {
-            sDipSwitches[j++] = 'F';
-        } else {
-            sDipSwitches[j++] = '0';
-        }
+    for (i = 0; i < 5; i++) {
+        sDipSwitches[j++] = (sGroup[i] == '0') ? 'F' : '0';
     }
 
-    for (i=0; i < 5; i++) {
-        if (sDevice[i] == '0') {
-            sDipSwitches[j++] = 'F';
-        } else {
-            sDipSwitches[j++] = '0';
-        }
+    for (i = 0; i < 5; i++) {
+        sDipSwitches[j++] = (sDevice[i] == '0') ? 'F' : '0';
     }
 
-    if ( bOn ) {
+    if (bOn) {
         sDipSwitches[j++] = '0';
         sDipSwitches[j++] = 'F';
     } else {
@@ -343,7 +335,12 @@ char* RCSwitch::getCodeWordC(char sFamily, int nGroup, int nDevice, boolean bSta
   }
   
   const char* sDeviceGroupCode =  dec2binWzerofill(  (nDevice-1) + (nGroup-1)*4, 4  );
-  const char familycode[16][5] = { "0000", "F000", "0F00", "FF00", "00F0", "F0F0", "0FF0", "FFF0", "000F", "F00F", "0F0F", "FF0F", "00FF", "F0FF", "0FFF", "FFFF" };
+  const char familycode[16][5] = {
+      "0000", "F000", "0F00", "FF00",
+      "00F0", "F0F0", "0FF0", "FFF0",
+      "000F", "F00F", "0F0F", "FF0F",
+      "00FF", "F0FF", "0FFF", "FFFF"
+      };
   for (int i = 0; i<4; i++) {
     sReturn[nReturnPos++] = familycode[ (int)sFamily - 97 ][i];
   }
@@ -407,8 +404,7 @@ char* RCSwitch::getCodeWordD(char sGroup, int nDevice, boolean bStatus){
             return '\0';
     }
     
-    for (int i = 0; i<4; i++)
-    {
+    for (int i = 0; i<4; i++) {
         sReturn[nReturnPos++] = sGroupCode[i];
     }
 
@@ -470,8 +466,8 @@ void RCSwitch::sendTriState(const char* sCodeWord) {
   }
 }
 
-void RCSwitch::send(unsigned long Code, unsigned int length) {
-  this->send( this->dec2binWzerofill(Code, length) );
+void RCSwitch::send(unsigned long code, unsigned int length) {
+  this->send( this->dec2binWzerofill(code, length) );
 }
 
 void RCSwitch::send(const char* sCodeWord) {
@@ -510,7 +506,7 @@ void RCSwitch::transmit(int nHighPulses, int nLowPulses) {
         delayMicroseconds( this->nPulseLength * nLowPulses);
         
         #if not defined( RCSwitchDisableReceiving )
-        if(disabled_Receive){
+        if(disabled_Receive) {
             this->enableReceive(nReceiverInterrupt_backup);
         }
         #endif
@@ -843,6 +839,3 @@ char* RCSwitch::dec2binWcharfill(unsigned long Dec, unsigned int bitLength, char
   
   return bin;
 }
-
-
-

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -534,8 +534,8 @@ void RCSwitch::send1() {
  * Waveform: | |___| |___
  */
 void RCSwitch::sendT0() {
-  this->transmit(1,3);
-  this->transmit(1,3);
+  this->send0();
+  this->send0();
 }
 
 /**
@@ -544,8 +544,8 @@ void RCSwitch::sendT0() {
  * Waveform: |   |_|   |_
  */
 void RCSwitch::sendT1() {
-  this->transmit(3,1);
-  this->transmit(3,1);
+  this->send1();
+  this->send1();
 }
 
 /**
@@ -554,8 +554,8 @@ void RCSwitch::sendT1() {
  * Waveform: | |___|   |_
  */
 void RCSwitch::sendTF() {
-  this->transmit(1,3);
-  this->transmit(3,1);
+  this->send0();
+  this->send1();
 }
 
 /**

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -326,7 +326,7 @@ char* RCSwitch::getCodeWordC(char sFamily, int nGroup, int nDevice, boolean bSta
     return '\0';
   }
   
-  const char* sDeviceGroupCode =  dec2binWzerofill(  (nDevice-1) + (nGroup-1)*4, 4  );
+  const char* sDeviceGroupCode =  dec2binWcharfill(  (nDevice-1) + (nGroup-1)*4, 4, '0'  );
   const char familycode[16][5] = {
       "0000", "F000", "0F00", "FF00",
       "00F0", "F0F0", "0FF0", "FFF0",
@@ -459,7 +459,7 @@ void RCSwitch::sendTriState(const char* sCodeWord) {
 }
 
 void RCSwitch::send(unsigned long code, unsigned int length) {
-  this->send( this->dec2binWzerofill(code, length) );
+  this->send( this->dec2binWcharfill(code, length, '0') );
 }
 
 void RCSwitch::send(const char* sCodeWord) {
@@ -709,10 +709,6 @@ void RCSwitch::handleInterrupt() {
 /**
   * Turns a decimal value to its binary representation
   */
-char* RCSwitch::dec2binWzerofill(unsigned long Dec, unsigned int bitLength){
-    return dec2binWcharfill(Dec, bitLength, '0');
-}
-
 char* RCSwitch::dec2binWcharfill(unsigned long Dec, unsigned int bitLength, char fill){
   static char bin[64];
   unsigned int i=0;

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -67,24 +67,25 @@ RCSwitch::RCSwitch() {
 /**
   * Sets the protocol to send.
   */
+void RCSwitch::setProtocol(Protocol protocol) {
+  this->protocol = protocol;
+}
+
+/**
+  * Sets the protocol to send, from a list of predefined protocols
+  */
 void RCSwitch::setProtocol(int nProtocol) {
-  if (nProtocol <= 0 || nProtocol > numProto) {
-    this->nProtocol = 1;  // TODO: trigger an error, e.g. "bad protocol" ???
-  } else {
-    this->nProtocol = nProtocol;
+  if (nProtocol <= 0 || nProtocol >= numProto) {
+    nProtocol = 1;  // TODO: trigger an error, e.g. "bad protocol" ???
   }
-  this->setPulseLength(proto[nProtocol].pulseLength);
+  this->protocol = proto[nProtocol];
 }
 
 /**
   * Sets the protocol to send with pulse length in microseconds.
   */
 void RCSwitch::setProtocol(int nProtocol, int nPulseLength) {
-  if (nProtocol <= 0 || nProtocol > numProto) {
-    this->nProtocol = 1;  // TODO: trigger an error, e.g. "bad protocol" ???
-  } else {
-    this->nProtocol = nProtocol;
-  }
+  setProtocol(nProtocol);
   this->setPulseLength(nPulseLength);
 }
 
@@ -93,7 +94,7 @@ void RCSwitch::setProtocol(int nProtocol, int nPulseLength) {
   * Sets pulse length in microseconds
   */
 void RCSwitch::setPulseLength(int nPulseLength) {
-  this->nPulseLength = nPulseLength;
+  this->protocol.pulseLength = nPulseLength;
 }
 
 /**
@@ -493,9 +494,9 @@ void RCSwitch::transmit(int nHighPulses, int nLowPulses) {
         }
         #endif
         digitalWrite(this->nTransmitterPin, HIGH);
-        delayMicroseconds( this->nPulseLength * nHighPulses);
+        delayMicroseconds( this->protocol.pulseLength * nHighPulses);
         digitalWrite(this->nTransmitterPin, LOW);
-        delayMicroseconds( this->nPulseLength * nLowPulses);
+        delayMicroseconds( this->protocol.pulseLength * nLowPulses);
         
         #if not defined( RCSwitchDisableReceiving )
         if(disabled_Receive) {
@@ -517,7 +518,7 @@ void RCSwitch::transmit(HighLow pulses) {
  * Waveform Protocol 2: | |__
  */
 void RCSwitch::send0() {
-    this->transmit(proto[nProtocol].zero);
+    this->transmit(protocol.zero);
 }
 
 /**
@@ -528,7 +529,7 @@ void RCSwitch::send0() {
  * Waveform Protocol 2: |  |_
  */
 void RCSwitch::send1() {
-    this->transmit(proto[nProtocol].one);
+    this->transmit(protocol.one);
 }
 
 
@@ -570,7 +571,7 @@ void RCSwitch::sendTF() {
  * Waveform Protocol 2: | |__________
  */
 void RCSwitch::sendSync() {
-    this->transmit(proto[nProtocol].syncFactor);
+    this->transmit(protocol.syncFactor);
 }
 
 #if not defined( RCSwitchDisableReceiving )

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -49,8 +49,8 @@ const unsigned int RCSwitch::nSeparationLimit = 4600;
 // separationLimit: minimum microseconds between received codes, closer codes are ignored.
 // according to discussion on issue #14 it might be more suitable to set the separation
 // limit to the same time as the 'low' part of the sync signal for the current protocol.
-#endif
 unsigned int RCSwitch::timings[RCSWITCH_MAX_CHANGES];
+#endif
 
 RCSwitch::RCSwitch() {
   this->nTransmitterPin = -1;

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -683,7 +683,7 @@ bool RCSwitch::receiveProtocol1(unsigned int changeCount){
     
       unsigned long code = 0;
       unsigned long delay = RCSwitch::timings[0] / PROTOCOL1_SYNC_FACTOR;
-      unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance * 0.01;    
+      unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance / 100;    
 
       for (unsigned int i = 1; i<changeCount ; i=i+2) {
       
@@ -713,7 +713,7 @@ bool RCSwitch::receiveProtocol2(unsigned int changeCount){
     
       unsigned long code = 0;
       unsigned long delay = RCSwitch::timings[0] / PROTOCOL2_SYNC_FACTOR;
-      unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance * 0.01;    
+      unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance / 100;    
 
       for (unsigned int i = 1; i<changeCount ; i=i+2) {
       
@@ -746,7 +746,7 @@ bool RCSwitch::receiveProtocol3(unsigned int changeCount){
     
       unsigned long code = 0;
       unsigned long delay = RCSwitch::timings[0] / PROTOCOL3_SYNC_FACTOR;
-      unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance * 0.01;    
+      unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance / 100;    
 
       for (unsigned int i = 1; i<changeCount ; i=i+2) {
       

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -233,14 +233,16 @@ void RCSwitch::switchOff(const char* sGroup, const char* sDevice) {
 }
 
 /**
- * Returns a char[13], representing the Code Word to be send.
- * A Code Word consists of 9 address bits, 3 data bits and one sync bit but in our case only the first 8 address bits and the last 2 data bits were used.
- * A Code Bit can have 4 different states: "F" (floating), "0" (low), "1" (high), "S" (synchronous bit)
+ * Returns a char[13], representing the code word to be sent.
+ * A code word consists of 9 address bits, 3 data bits and one sync bit but
+ * in our case only the first 8 address bits and the last 2 data bits were used.
+ * A code bit can have 4 different states: "F" (floating), "0" (low), "1" (high), "S" (sync bit)
  *
- * +-------------------------------+--------------------------------+-----------------------------------------+-----------------------------------------+----------------------+------------+
- * | 4 bits address (switch group) | 4 bits address (switch number) | 1 bit address (not used, so never mind) | 1 bit address (not used, so never mind) | 2 data bits (on|off) | 1 sync bit |
- * | 1=0FFF 2=F0FF 3=FF0F 4=FFF0   | 1=0FFF 2=F0FF 3=FF0F 4=FFF0    | F                                       | F                                       | on=FF off=F0         | S          |
- * +-------------------------------+--------------------------------+-----------------------------------------+-----------------------------------------+----------------------+------------+
+ * +-----------------------------+-----------------------------+----------+----------+--------------+----------+
+ * | 4 bits address              | 4 bits address              | 1 bit    | 1 bit    | 2 bits       | 1 bit    |
+ * | switch group                | switch number               | not used | not used | on / off     | sync bit |
+ * | 1=0FFF 2=F0FF 3=FF0F 4=FFF0 | 1=0FFF 2=F0FF 3=FF0F 4=FFF0 | F        | F        | on=FF off=F0 | S        |
+ * +-----------------------------+-----------------------------+----------+----------+--------------+----------+
  *
  * @param nAddressCode  Number of the switch group (1..4)
  * @param nChannelCode  Number of the switch itself (1..4)

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -30,7 +30,7 @@
 #include "RCSwitch.h"
 
 #if not defined( RCSwitchDisableReceiving )
-unsigned long RCSwitch::nReceivedValue = NULL;
+unsigned long RCSwitch::nReceivedValue = 0;
 unsigned int RCSwitch::nReceivedBitlength = 0;
 unsigned int RCSwitch::nReceivedDelay = 0;
 unsigned int RCSwitch::nReceivedProtocol = 0;
@@ -50,7 +50,7 @@ RCSwitch::RCSwitch() {
   #if not defined( RCSwitchDisableReceiving )
   this->nReceiverInterrupt = -1;
   this->setReceiveTolerance(60);
-  RCSwitch::nReceivedValue = NULL;
+  RCSwitch::nReceivedValue = 0;
   #endif
 }
 
@@ -622,8 +622,8 @@ void RCSwitch::enableReceive(int interrupt) {
 
 void RCSwitch::enableReceive() {
   if (this->nReceiverInterrupt != -1) {
-    RCSwitch::nReceivedValue = NULL;
-    RCSwitch::nReceivedBitlength = NULL;
+    RCSwitch::nReceivedValue = 0;
+    RCSwitch::nReceivedBitlength = 0;
     attachInterrupt(this->nReceiverInterrupt, handleInterrupt, CHANGE);
   }
 }
@@ -637,11 +637,11 @@ void RCSwitch::disableReceive() {
 }
 
 bool RCSwitch::available() {
-  return RCSwitch::nReceivedValue != NULL;
+  return RCSwitch::nReceivedValue != 0;
 }
 
 void RCSwitch::resetAvailable() {
-  RCSwitch::nReceivedValue = NULL;
+  RCSwitch::nReceivedValue = 0;
 }
 
 unsigned long RCSwitch::getReceivedValue() {
@@ -673,7 +673,7 @@ bool RCSwitch::receiveProtocol1(unsigned int changeCount){
       unsigned long delay = RCSwitch::timings[0] / 31;
       unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance * 0.01;    
 
-      for (int i = 1; i<changeCount ; i=i+2) {
+      for (unsigned int i = 1; i<changeCount ; i=i+2) {
       
           if (RCSwitch::timings[i] > delay-delayTolerance && RCSwitch::timings[i] < delay+delayTolerance && RCSwitch::timings[i+1] > delay*3-delayTolerance && RCSwitch::timings[i+1] < delay*3+delayTolerance) {
             code = code << 1;
@@ -694,13 +694,7 @@ bool RCSwitch::receiveProtocol1(unsigned int changeCount){
       RCSwitch::nReceivedProtocol = 1;
     }
 
-    if (code == 0){
-        return false;
-    }else if (code != 0){
-        return true;
-    }
-    
-
+    return code != 0;
 }
 
 bool RCSwitch::receiveProtocol2(unsigned int changeCount){
@@ -709,7 +703,7 @@ bool RCSwitch::receiveProtocol2(unsigned int changeCount){
       unsigned long delay = RCSwitch::timings[0] / 10;
       unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance * 0.01;    
 
-      for (int i = 1; i<changeCount ; i=i+2) {
+      for (unsigned int i = 1; i<changeCount ; i=i+2) {
       
           if (RCSwitch::timings[i] > delay-delayTolerance && RCSwitch::timings[i] < delay+delayTolerance && RCSwitch::timings[i+1] > delay*2-delayTolerance && RCSwitch::timings[i+1] < delay*2+delayTolerance) {
             code = code << 1;
@@ -730,12 +724,7 @@ bool RCSwitch::receiveProtocol2(unsigned int changeCount){
       RCSwitch::nReceivedProtocol = 2;
     }
 
-    if (code == 0){
-        return false;
-    }else if (code != 0){
-        return true;
-    }
-
+    return code != 0;
 }
 
 /** Protocol 3 is used by BL35P02.
@@ -747,7 +736,7 @@ bool RCSwitch::receiveProtocol3(unsigned int changeCount){
       unsigned long delay = RCSwitch::timings[0] / PROTOCOL3_SYNC_FACTOR;
       unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance * 0.01;    
 
-      for (int i = 1; i<changeCount ; i=i+2) {
+      for (unsigned int i = 1; i<changeCount ; i=i+2) {
       
           if  (RCSwitch::timings[i]   > delay*PROTOCOL3_0_HIGH_CYCLES - delayTolerance
             && RCSwitch::timings[i]   < delay*PROTOCOL3_0_HIGH_CYCLES + delayTolerance
@@ -774,11 +763,7 @@ bool RCSwitch::receiveProtocol3(unsigned int changeCount){
         RCSwitch::nReceivedProtocol = 3;
       }
 
-      if (code == 0){
-        return false;
-      }else if (code != 0){
-        return true;
-      }
+    return code != 0;
 }
 
 void RCSwitch::handleInterrupt() {

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -251,7 +251,7 @@ void RCSwitch::switchOff(const char* sGroup, const char* sDevice) {
  *
  * @param nAddressCode  Number of the switch group (1..4)
  * @param nChannelCode  Number of the switch itself (1..4)
- * @param bStatus       Wether to switch on (true) or off (false)
+ * @param bStatus       Whether to switch on (true) or off (false)
  *
  * @return char[13]
  */
@@ -287,7 +287,7 @@ char* RCSwitch::getCodeWordB(int nAddressCode, int nChannelCode, boolean bStatus
 }
 
 /**
- * Returns a char[13], representing the Code Word to be send.
+ * Returns a char[13], representing the code word to be send.
  *
  */
 char* RCSwitch::getCodeWordA(const char* sGroup, const char* sDevice, boolean bOn) {

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -71,20 +71,12 @@ RCSwitch::RCSwitch() {
   */
 void RCSwitch::setProtocol(int nProtocol) {
   this->nProtocol = nProtocol;
-  if (nProtocol == 1){
-    this->setPulseLength(350);
-  }
-  else if (nProtocol == 2) {
-    this->setPulseLength(650);
-  }
-  else if (nProtocol == 3) {
-    this->setPulseLength(100);
-  }
-  else if (nProtocol == 4) {
-    this->setPulseLength(380);
-  }
-  else if (nProtocol == 5) {
-    this->setPulseLength(500);
+  switch (nProtocol) {
+    case 1: this->setPulseLength(350); break;
+    case 2: this->setPulseLength(650); break;
+    case 3: this->setPulseLength(100); break;
+    case 4: this->setPulseLength(380); break;
+    case 5: this->setPulseLength(500); break;
   }
 }
 
@@ -520,20 +512,18 @@ void RCSwitch::transmit(int nHighPulses, int nLowPulses) {
  * Waveform Protocol 2: | |__
  */
 void RCSwitch::send0() {
-    if (this->nProtocol == 1){
+    switch (this->nProtocol) {
+    case 1:
+    case 4:
         this->transmit(1,3);
-    }
-    else if (this->nProtocol == 2) {
+        break;
+    case 2:
+    case 5:
         this->transmit(1,2);
-    }
-    else if (this->nProtocol == 3) {
-        this->transmit(PROTOCOL3_0_HIGH_CYCLES,PROTOCOL3_0_LOW_CYCLES);
-    }
-    else if (this->nProtocol == 4) {
-        this->transmit(1,3);
-    }
-    else if (this->nProtocol == 5) {
-        this->transmit(1,2);
+        break;
+    case 3:
+        this->transmit(PROTOCOL3_0_HIGH_CYCLES, PROTOCOL3_0_LOW_CYCLES);
+        break;
     }
 }
 
@@ -545,20 +535,18 @@ void RCSwitch::send0() {
  * Waveform Protocol 2: |  |_
  */
 void RCSwitch::send1() {
-      if (this->nProtocol == 1){
+    switch (this->nProtocol) {
+    case 1:
+    case 4:
         this->transmit(3,1);
-    }
-    else if (this->nProtocol == 2) {
+        break;
+    case 2:
+    case 5:
         this->transmit(2,1);
-    }
-    else if (this->nProtocol == 3) {
-        this->transmit(PROTOCOL3_1_HIGH_CYCLES,PROTOCOL3_1_LOW_CYCLES);
-    }
-    else if (this->nProtocol == 4) {
-        this->transmit(3,1);
-    }
-	else if (this->nProtocol == 5) {
-        this->transmit(2,1);
+        break;
+    case 3:
+        this->transmit(PROTOCOL3_1_HIGH_CYCLES, PROTOCOL3_1_LOW_CYCLES);
+        break;
     }
 }
 
@@ -602,20 +590,22 @@ void RCSwitch::sendTF() {
  */
 void RCSwitch::sendSync() {
 
-    if (this->nProtocol == 1){
+    switch (this->nProtocol) {
+    case 1:
         this->transmit(1,PROTOCOL1_SYNC_FACTOR);
-    }
-    else if (this->nProtocol == 2) {
+        break;
+    case 2:
         this->transmit(1,PROTOCOL2_SYNC_FACTOR);
-    }
-    else if (this->nProtocol == 3) {
+        break;
+    case 3:
         this->transmit(1,PROTOCOL3_SYNC_FACTOR);
-    }
-    else if (this->nProtocol == 4) {
+        break;
+    case 4:
         this->transmit(1,6);
-    }
-    else if (this->nProtocol == 5) {
+        break;
+    case 5:
         this->transmit(6,14);
+        break;
     }
 }
 

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -627,7 +627,7 @@ unsigned int* RCSwitch::getReceivedRawdata() {
 }
 
 /* helper function for the various receiveProtocol methods */
-static inline unsigned long diff(long A, long B) {
+static inline unsigned int diff(int A, int B) {
     return abs(A - B);
 }
 
@@ -640,8 +640,8 @@ bool RCSwitch::receiveProtocol(const int p, unsigned int changeCount) {
     memcpy_P(&pro, &proto[p-1], sizeof(Protocol));
 
     unsigned long code = 0;
-    const unsigned long delay = RCSwitch::timings[0] / pro.syncFactor.low;
-    const unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance / 100;
+    const unsigned int delay = RCSwitch::timings[0] / pro.syncFactor.low;
+    const unsigned int delayTolerance = delay * RCSwitch::nReceiveTolerance / 100;
 
     for (unsigned int i = 1; i < changeCount; i += 2) {
         code <<= 1;

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -29,6 +29,18 @@
 
 #include "RCSwitch.h"
 
+enum {
+    PROTOCOL1_SYNC_FACTOR       = 31,
+
+    PROTOCOL2_SYNC_FACTOR       = 10,
+
+    PROTOCOL3_SYNC_FACTOR       = 71,
+    PROTOCOL3_0_HIGH_CYCLES     = 4,
+    PROTOCOL3_0_LOW_CYCLES      = 11,
+    PROTOCOL3_1_HIGH_CYCLES     = 9,
+    PROTOCOL3_1_LOW_CYCLES      = 6
+};
+
 #if not defined( RCSwitchDisableReceiving )
 unsigned long RCSwitch::nReceivedValue = 0;
 unsigned int RCSwitch::nReceivedBitlength = 0;
@@ -519,7 +531,7 @@ void RCSwitch::send0() {
         this->transmit(1,2);
     }
     else if (this->nProtocol == 3) {
-        this->transmit(4,11);
+        this->transmit(PROTOCOL3_0_HIGH_CYCLES,PROTOCOL3_0_LOW_CYCLES);
     }
     else if (this->nProtocol == 4) {
         this->transmit(1,3);
@@ -544,7 +556,7 @@ void RCSwitch::send1() {
         this->transmit(2,1);
     }
     else if (this->nProtocol == 3) {
-        this->transmit(9,6);
+        this->transmit(PROTOCOL3_1_HIGH_CYCLES,PROTOCOL3_1_LOW_CYCLES);
     }
     else if (this->nProtocol == 4) {
         this->transmit(3,1);
@@ -595,13 +607,13 @@ void RCSwitch::sendTF() {
 void RCSwitch::sendSync() {
 
     if (this->nProtocol == 1){
-        this->transmit(1,31);
+        this->transmit(1,PROTOCOL1_SYNC_FACTOR);
     }
     else if (this->nProtocol == 2) {
-        this->transmit(1,10);
+        this->transmit(1,PROTOCOL2_SYNC_FACTOR);
     }
     else if (this->nProtocol == 3) {
-        this->transmit(1,71);
+        this->transmit(1,PROTOCOL3_SYNC_FACTOR);
     }
     else if (this->nProtocol == 4) {
         this->transmit(1,6);
@@ -670,7 +682,7 @@ unsigned int* RCSwitch::getReceivedRawdata() {
 bool RCSwitch::receiveProtocol1(unsigned int changeCount){
     
       unsigned long code = 0;
-      unsigned long delay = RCSwitch::timings[0] / 31;
+      unsigned long delay = RCSwitch::timings[0] / PROTOCOL1_SYNC_FACTOR;
       unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance * 0.01;    
 
       for (unsigned int i = 1; i<changeCount ; i=i+2) {
@@ -700,7 +712,7 @@ bool RCSwitch::receiveProtocol1(unsigned int changeCount){
 bool RCSwitch::receiveProtocol2(unsigned int changeCount){
     
       unsigned long code = 0;
-      unsigned long delay = RCSwitch::timings[0] / 10;
+      unsigned long delay = RCSwitch::timings[0] / PROTOCOL2_SYNC_FACTOR;
       unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance * 0.01;    
 
       for (unsigned int i = 1; i<changeCount ; i=i+2) {

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -481,15 +481,11 @@ void RCSwitch::send(const char* sCodeWord) {
 }
 
 void RCSwitch::transmit(int nHighPulses, int nLowPulses) {
-    #if not defined ( RCSwitchDisableReceiving )
-    boolean disabled_Receive = false;
-    int nReceiverInterrupt_backup = nReceiverInterrupt;
-    #endif
     if (this->nTransmitterPin != -1) {
         #if not defined( RCSwitchDisableReceiving )
-        if (this->nReceiverInterrupt != -1) {
+        int nReceiverInterrupt_backup = nReceiverInterrupt;
+        if (nReceiverInterrupt_backup != -1) {
             this->disableReceive();
-            disabled_Receive = true;
         }
         #endif
         digitalWrite(this->nTransmitterPin, HIGH);
@@ -498,7 +494,7 @@ void RCSwitch::transmit(int nHighPulses, int nLowPulses) {
         delayMicroseconds( this->protocol.pulseLength * nLowPulses);
         
         #if not defined( RCSwitchDisableReceiving )
-        if(disabled_Receive) {
+        if (nReceiverInterrupt_backup != -1) {
             this->enableReceive(nReceiverInterrupt_backup);
         }
         #endif

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -189,26 +189,26 @@ void RCSwitch::switchOff(int nAddressCode, int nChannelCode) {
 }
 
 /**
- * Deprecated, use switchOn(char* sGroup, char* sDevice) instead!
+ * Deprecated, use switchOn(const char* sGroup, const char* sDevice) instead!
  * Switch a remote switch on (Type A with 10 pole DIP switches)
  *
  * @param sGroup        Code of the switch group (refers to DIP switches 1..5 where "1" = on and "0" = off, if all DIP switches are on it's "11111")
  * @param nChannelCode  Number of the switch itself (1..5)
  */
-void RCSwitch::switchOn(char* sGroup, int nChannel) {
-  char* code[6] = { "00000", "10000", "01000", "00100", "00010", "00001" };
+void RCSwitch::switchOn(const char* sGroup, int nChannel) {
+  const char* code[6] = { "00000", "10000", "01000", "00100", "00010", "00001" };
   this->switchOn(sGroup, code[nChannel]);
 }
 
 /**
- * Deprecated, use switchOff(char* sGroup, char* sDevice) instead!
+ * Deprecated, use switchOff(const char* sGroup, const char* sDevice) instead!
  * Switch a remote switch off (Type A with 10 pole DIP switches)
  *
  * @param sGroup        Code of the switch group (refers to DIP switches 1..5 where "1" = on and "0" = off, if all DIP switches are on it's "11111")
  * @param nChannelCode  Number of the switch itself (1..5)
  */
-void RCSwitch::switchOff(char* sGroup, int nChannel) {
-  char* code[6] = { "00000", "10000", "01000", "00100", "00010", "00001" };
+void RCSwitch::switchOff(const char* sGroup, int nChannel) {
+  const char* code[6] = { "00000", "10000", "01000", "00100", "00010", "00001" };
   this->switchOff(sGroup, code[nChannel]);
 }
 
@@ -218,7 +218,7 @@ void RCSwitch::switchOff(char* sGroup, int nChannel) {
  * @param sGroup        Code of the switch group (refers to DIP switches 1..5 where "1" = on and "0" = off, if all DIP switches are on it's "11111")
  * @param sDevice       Code of the switch device (refers to DIP switches 6..10 (A..E) where "1" = on and "0" = off, if all DIP switches are on it's "11111")
  */
-void RCSwitch::switchOn(char* sGroup, char* sDevice) {
+void RCSwitch::switchOn(const char* sGroup, const char* sDevice) {
     this->sendTriState( this->getCodeWordA(sGroup, sDevice, true) );
 }
 
@@ -228,7 +228,7 @@ void RCSwitch::switchOn(char* sGroup, char* sDevice) {
  * @param sGroup        Code of the switch group (refers to DIP switches 1..5 where "1" = on and "0" = off, if all DIP switches are on it's "11111")
  * @param sDevice       Code of the switch device (refers to DIP switches 6..10 (A..E) where "1" = on and "0" = off, if all DIP switches are on it's "11111")
  */
-void RCSwitch::switchOff(char* sGroup, char* sDevice) {
+void RCSwitch::switchOff(const char* sGroup, const char* sDevice) {
     this->sendTriState( this->getCodeWordA(sGroup, sDevice, false) );
 }
 
@@ -252,7 +252,7 @@ char* RCSwitch::getCodeWordB(int nAddressCode, int nChannelCode, boolean bStatus
    int nReturnPos = 0;
    static char sReturn[13];
    
-   char* code[5] = { "FFFF", "0FFF", "F0FF", "FF0F", "FFF0" };
+   const char* code[5] = { "FFFF", "0FFF", "F0FF", "FF0F", "FFF0" };
    if (nAddressCode < 1 || nAddressCode > 4 || nChannelCode < 1 || nChannelCode > 4) {
     return '\0';
    }
@@ -282,10 +282,8 @@ char* RCSwitch::getCodeWordB(int nAddressCode, int nChannelCode, boolean bStatus
 /**
  * Returns a char[13], representing the Code Word to be send.
  *
- * getCodeWordA(char*, char*)
- *
  */
-char* RCSwitch::getCodeWordA(char* sGroup, char* sDevice, boolean bOn) {
+char* RCSwitch::getCodeWordA(const char* sGroup, const char* sDevice, boolean bOn) {
     static char sDipSwitches[13];
     int i = 0;
     int j = 0;
@@ -330,8 +328,8 @@ char* RCSwitch::getCodeWordC(char sFamily, int nGroup, int nDevice, boolean bSta
     return '\0';
   }
   
-  char* sDeviceGroupCode =  dec2binWzerofill(  (nDevice-1) + (nGroup-1)*4, 4  );
-  char familycode[16][5] = { "0000", "F000", "0F00", "FF00", "00F0", "F0F0", "0FF0", "FFF0", "000F", "F00F", "0F0F", "FF0F", "00FF", "F0FF", "0FFF", "FFFF" };
+  const char* sDeviceGroupCode =  dec2binWzerofill(  (nDevice-1) + (nGroup-1)*4, 4  );
+  const char familycode[16][5] = { "0000", "F000", "0F00", "FF00", "00F0", "F0F0", "0FF0", "FFF0", "000F", "F00F", "0F0F", "FF0F", "00FF", "F0FF", "0FFF", "FFFF" };
   for (int i = 0; i<4; i++) {
     sReturn[nReturnPos++] = familycode[ (int)sFamily - 97 ][i];
   }
@@ -437,7 +435,7 @@ char* RCSwitch::getCodeWordD(char sGroup, int nDevice, boolean bStatus){
 /**
  * @param sCodeWord   /^[10FS]*$/  -> see getCodeWord
  */
-void RCSwitch::sendTriState(char* sCodeWord) {
+void RCSwitch::sendTriState(const char* sCodeWord) {
   for (int nRepeat=0; nRepeat<nRepeatTransmit; nRepeat++) {
     int i = 0;
     while (sCodeWord[i] != '\0') {
@@ -462,7 +460,7 @@ void RCSwitch::send(unsigned long Code, unsigned int length) {
   this->send( this->dec2binWzerofill(Code, length) );
 }
 
-void RCSwitch::send(char* sCodeWord) {
+void RCSwitch::send(const char* sCodeWord) {
   for (int nRepeat=0; nRepeat<nRepeatTransmit; nRepeat++) {
     int i = 0;
     while (sCodeWord[i] != '\0') {

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -60,18 +60,18 @@ class RCSwitch {
     
     void switchOn(int nGroupNumber, int nSwitchNumber);
     void switchOff(int nGroupNumber, int nSwitchNumber);
-    void switchOn(char* sGroup, int nSwitchNumber);
-    void switchOff(char* sGroup, int nSwitchNumber);
+    void switchOn(const char* sGroup, int nSwitchNumber);
+    void switchOff(const char* sGroup, int nSwitchNumber);
     void switchOn(char sFamily, int nGroup, int nDevice);
     void switchOff(char sFamily, int nGroup, int nDevice);
-    void switchOn(char* sGroup, char* sDevice);
-    void switchOff(char* sGroup, char* sDevice);
+    void switchOn(const char* sGroup, const char* sDevice);
+    void switchOff(const char* sGroup, const char* sDevice);
     void switchOn(char sGroup, int nDevice);
     void switchOff(char sGroup, int nDevice);
 
-    void sendTriState(char* Code);
+    void sendTriState(const char* Code);
     void send(unsigned long Code, unsigned int length);
-    void send(char* Code);
+    void send(const char* Code);
     
     #if not defined( RCSwitchDisableReceiving )
     void enableReceive(int interrupt);
@@ -99,8 +99,8 @@ class RCSwitch {
   
   private:
     char* getCodeWordB(int nGroupNumber, int nSwitchNumber, boolean bStatus);
-    char* getCodeWordA(char* sGroup, int nSwitchNumber, boolean bStatus);
-    char* getCodeWordA(char* sGroup, char* sDevice, boolean bStatus);
+    char* getCodeWordA(const char* sGroup, int nSwitchNumber, boolean bStatus);
+    char* getCodeWordA(const char* sGroup, const char* sDevice, boolean bStatus);
     char* getCodeWordC(char sFamily, int nGroup, int nDevice, boolean bStatus);
     char* getCodeWordD(char group, int nDevice, boolean bStatus);
     void sendT0();

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -140,11 +140,11 @@ class RCSwitch {
     static unsigned int nReceivedDelay;
     static unsigned int nReceivedProtocol;
     const static unsigned int nSeparationLimit;
-    #endif
     /* 
      * timings[0] contains sync timing, followed by a number of bits
      */
     static unsigned int timings[RCSWITCH_MAX_CHANGES];
+    #endif
 
     
 };

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -101,6 +101,7 @@ class RCSwitch {
         HighLow one;
     };
 
+    void setProtocol(Protocol protocol);
     void setProtocol(int nProtocol);
     void setProtocol(int nProtocol, int nPulseLength);
 
@@ -128,9 +129,9 @@ class RCSwitch {
     int nReceiverInterrupt;
     #endif
     int nTransmitterPin;
-    int nPulseLength;
     int nRepeatTransmit;
-    int nProtocol;
+    
+    Protocol protocol;
 
     #if not defined( RCSwitchDisableReceiving )
     static int nReceiveTolerance;

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -47,12 +47,6 @@
 // We can handle up to (unsigned long) => 32 bit * 2 H/L changes per bit + 2 for sync
 #define RCSWITCH_MAX_CHANGES 67
 
-#define PROTOCOL3_SYNC_FACTOR   71
-#define PROTOCOL3_0_HIGH_CYCLES  4
-#define PROTOCOL3_0_LOW_CYCLES  11
-#define PROTOCOL3_1_HIGH_CYCLES  9
-#define PROTOCOL3_1_LOW_CYCLES   6
-
 class RCSwitch {
 
   public:

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -88,9 +88,22 @@ class RCSwitch {
     #if not defined( RCSwitchDisableReceiving )
     void setReceiveTolerance(int nPercent);
     #endif
+
+    struct HighLow {
+        byte high;
+        byte low;
+    };
+
+    struct Protocol {
+        int pulseLength;
+        HighLow syncFactor;
+        HighLow zero;
+        HighLow one;
+    };
+
     void setProtocol(int nProtocol);
     void setProtocol(int nProtocol, int nPulseLength);
-  
+
   private:
     char* getCodeWordB(int nGroupNumber, int nSwitchNumber, boolean bStatus);
     char* getCodeWordA(const char* sGroup, int nSwitchNumber, boolean bStatus);
@@ -104,21 +117,20 @@ class RCSwitch {
     void send1();
     void sendSync();
     void transmit(int nHighPulses, int nLowPulses);
+    void transmit(HighLow pulses);
 
     static char* dec2binWzerofill(unsigned long dec, unsigned int length);
     static char* dec2binWcharfill(unsigned long dec, unsigned int length, char fill);
     
     #if not defined( RCSwitchDisableReceiving )
     static void handleInterrupt();
-    static bool receiveProtocol1(unsigned int changeCount);
-    static bool receiveProtocol2(unsigned int changeCount);
-    static bool receiveProtocol3(unsigned int changeCount);
+    static bool receiveProtocol(const int p, unsigned int changeCount);
     int nReceiverInterrupt;
     #endif
     int nTransmitterPin;
     int nPulseLength;
     int nRepeatTransmit;
-    char nProtocol;
+    int nProtocol;
 
     #if not defined( RCSwitchDisableReceiving )
     static int nReceiveTolerance;

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -31,7 +31,7 @@
 #if defined(ARDUINO) && ARDUINO >= 100
     #include "Arduino.h"
 #elif defined(ENERGIA) // LaunchPad, FraunchPad and StellarPad specific
-    #include "Energia.h"	
+    #include "Energia.h"
 #else
     #include "WProgram.h"
 #endif

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -120,7 +120,6 @@ class RCSwitch {
     void transmit(int nHighPulses, int nLowPulses);
     void transmit(HighLow pulses);
 
-    static char* dec2binWzerofill(unsigned long dec, unsigned int length);
     static char* dec2binWcharfill(unsigned long dec, unsigned int length, char fill);
     
     #if not defined( RCSwitchDisableReceiving )


### PR DESCRIPTION
This extends my previous PR #17 with some further refactoring: There is now a data structure `Protocols` which encodes the various protocol specific differences.

This has various benefits:
* Simpler code: E.g. the three `receiveProtocol*` methods were merged into a single one.
* More flexibility: There are countless protocol varations out there. E.g. protocols 1&2 are very similar to protocols 4&5; and I have a set of devices which use almost protocol 3 -- but the sync is 30/71 instead of 1/71. With the new `Protocol` struct, I can use that protocol without having to modifyi rc-switch.
* The overall code size is reduced (important for bigger projects). For example, let's look at `ReceiveDemo_Simple`:
  * with your master branch: 5,506 bytes program storage, 415 bytes of dynamic memory
  * with PR #17: 4,754 bytes program storage, 415 bytes of dynamic memory
  * with this PR: 3,606 bytes program storage, 420 bytes of dynamic memory
* Or consider `SendDemo`:
  * master: 6702 / 514
  * PR #17: 5946 / 514
  * this: 4522 / 487