### PR TITLE
Tweak initial high signal of protocol 3

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -53,7 +53,7 @@
 static const RCSwitch::Protocol PROGMEM proto[] = {
     { 350, {  1, 31 }, {  1,  3 }, {  3,  1 } },    // protocol 1
     { 650, {  1, 10 }, {  1,  2 }, {  2,  1 } },    // protocol 2
-    { 100, {  1, 71 }, {  4, 11 }, {  9,  6 } },    // protocol 3
+    { 100, { 30, 71 }, {  4, 11 }, {  9,  6 } },    // protocol 3
     { 380, {  1,  6 }, {  1,  3 }, {  3,  1 } },    // protocol 4
     { 500, {  6, 14 }, {  1,  2 }, {  2,  1 } },    // protocol 5
 };


### PR DESCRIPTION
This resolves issue #32 (with a recent Globaltronics GT-FSI-07), and also is necessary
for compatibility with my Brennenstuhl RCS 2044.

However, it might break existing users of protocol 3 (which is why I did not commit this directly). 

Unfortunately, I have no idea of which devices that might be. The commit 9f1bf100a7d621ea7eb80f69ceb4f17aabedced2 which added protocol 3 gives no hints (as far as I could tell) what devices need it. And the Wiki does not mention any device using protocol 3 either.

And of course our receiving code ignores the initial high (which one might consider a bug...) and thus *receiving* works well with our without this patch. So perhaps the device(s) for which protocol 3 was originally added are fine with this patch, too?