### PR TITLE
Iterate over all defined protocols in `handleInterrupt`

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -1,6 +1,6 @@
 /*
   RCSwitch - Arduino libary for remote control outlet switches
-  Copyright (c) 2011 Suat Ã–zgÃ¼r.  All right reserved.
+  Copyright (c) 2011 Suat Özgür.  All right reserved.
   
   Contributors:
   - Andre Koehler / info(at)tomate-online(dot)de
@@ -11,6 +11,7 @@
   - Andreas Steinel / A.<lastname>(at)gmail(dot)com
   - Max Horn / max(at)quendi(dot)de
   - Robert ter Vehn / <first name>.<last name>(at)gmail(dot)com
+  - Johann Richard / <first name>.<last name>(at)gmail(dot)com
   
   Project home: https://github.com/sui77/rc-switch/
 
@@ -706,13 +707,13 @@ void RCSwitch::handleInterrupt() {
     repeatCount++;
     changeCount--;
     if (repeatCount == 2) {
-      if (receiveProtocol(1, changeCount) == false) {
-        if (receiveProtocol(2, changeCount) == false) {
-          if (receiveProtocol(3, changeCount) == false) {
-            //failed
-          }
-        }
-      }
+	    if (repeatCount == 2) {
+			for(unsigned int i = 1; i < numProto; i++ ) {
+				if (receiveProtocol(i, changeCount))
+					exit;
+			}
+	      repeatCount = 0;
+	    }
       repeatCount = 0;
     }
     changeCount = 0;

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -1,6 +1,6 @@
 /*
   RCSwitch - Arduino libary for remote control outlet switches
-  Copyright (c) 2011 Suat Özgür.  All right reserved.
+  Copyright (c) 2011 Suat Ã–zgÃ¼r.  All right reserved.
   
   Contributors:
   - Andre Koehler / info(at)tomate-online(dot)de
@@ -707,13 +707,10 @@ void RCSwitch::handleInterrupt() {
     repeatCount++;
     changeCount--;
     if (repeatCount == 2) {
-	    if (repeatCount == 2) {
-			for(unsigned int i = 1; i < numProto; i++ ) {
-				if (receiveProtocol(i, changeCount))
-					exit;
-			}
-	      repeatCount = 0;
-	    }
+	for(unsigned int i = 1; i < numProto; i++ ) {
+		if (receiveProtocol(i, changeCount))
+			exit;
+	}
       repeatCount = 0;
     }
     changeCount = 0;


### PR DESCRIPTION
So far, while decoding the timings, the `handleInterrupt`routine only
iterated over protocols 1-3 before failing.

This small change will iterate over *all* protocols that have been
defined.