### PR TITLE
Travis integration + Readme changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+python:
+  - "2.7"
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+cache:
+  directories:
+      - "~/.platformio"
+
+env:
+  - PLATFORMIO_CI_SRC=examples/Webserver/
+  - PLATFORMIO_CI_SRC=examples/ReceiveDemo_Simple/
+  - PLATFORMIO_CI_SRC=examples/TypeC_Intertechno/
+  - PLATFORMIO_CI_SRC=examples/TypeD_REV/
+  - PLATFORMIO_CI_SRC=examples/TypeA_WithDIPSwitches/
+  - PLATFORMIO_CI_SRC=examples/TypeA_WithDIPSwitches_Lightweight/
+  - PLATFORMIO_CI_SRC=examples/TypeB_WithRotaryOrSlidingSwitches/
+  - PLATFORMIO_CI_SRC=examples/SendDemo/
+  - PLATFORMIO_CI_SRC=examples/ReceiveDemo_Advanced/
+
+install:
+  - pip install -U platformio
+
+script:
+  - platformio ci --lib="." --board=diecimilaatmega328

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # rc-switch
+[![Build Status](https://travis-ci.org/sui77/rc-switch.svg?branch=master)](https://travis-ci.org/sui77/rc-switch)
+
 Use your Arduino or Raspberry Pi to operate remote radio controlled devices
 
 ##Download

--- a/README.md
+++ b/README.md
@@ -3,24 +3,36 @@
 
 Use your Arduino or Raspberry Pi to operate remote radio controlled devices
 
-##Download
+## Download
 https://github.com/sui77/rc-switch/releases/latest
 
-##Wiki
+## Wiki
 https://github.com/sui77/rc-switch/wiki
 
-##Info
-###Send RC codes
+## Info
+### Send RC codes
 
-Use your Arduino or Raspberry Pi to operate remote radio controlled devices. This will most likely work with all popular low cost power outlet sockets. If yours doesn't work, you might need to adjust the pulse length for some to work.
+Use your Arduino or Raspberry Pi to operate remote radio controlled devices.
+This will most likely work with all popular low cost power outlet sockets. If
+yours doesn't work, you might need to adjust the pulse length.
 
-All you need is a Arduino or Raspberry Pi, a 315/433MHz AM transmitter  and one or more devices with a SC5262 / SC5272, HX2262 / HX2272, PT2262 / PT2272, EV1527, RT1527, FP1527 or HS1527 chipset. Also supports Intertechno outlets.
+All you need is a Arduino or Raspberry Pi, a 315/433MHz AM transmitter and one
+or more devices with one of the supported chipsets:
 
-###Receive and decode RC codes
+ - SC5262 / SC5272
+ - HX2262 / HX2272
+ - PT2262 / PT2272
+ - EV1527 / RT1527 / FP1527 / HS1527 
+ - Intertechno outlets
 
-Find out what codes your remote is sending. Use your remote to control your Arduino.
+### Receive and decode RC codes
 
-All you need is a Arduino, a 315/433MHz AM receiver (altough there is no instruction yet, yes it is possible to hack an existing device) and a remote hand set.
+Find out what codes your remote is sending. Use your remote to control your
+Arduino.
 
-For Raspberry Pi, clone the https://github.com/ninjablocks/433Utils project to compile a sniffer tool and transmission commands.
+All you need is an Arduino, a 315/433MHz AM receiver (altough there is no
+instruction yet, yes it is possible to hack an existing device) and a remote
+hand set.
 
+For the Raspberry Pi, clone the https://github.com/ninjablocks/433Utils project to
+compile a sniffer tool and transmission commands.


### PR DESCRIPTION
This adds CI via platform.io to verify that the examples compile and at least support an Arduino Diecimila.

Also some README formatting.

Here is what a green build looks like:
https://travis-ci.org/solarkennedy/rc-switch/builds/113960690

Obviously to enable this on your repo, you will have to enable travis-ci for this repo. (highly recommended, also powers the badge) This will give you confidence that your incoming pull requests are legit and the examples continue compile and work.