### PR TITLE
fix 2 bugs introduced in PR #35

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -708,9 +708,11 @@ void RCSwitch::handleInterrupt() {
     changeCount--;
     if (repeatCount == 2) {
 	for(unsigned int i = 1; i < numProto; i++ ) {
-		if (receiveProtocol(i, changeCount))
-			exit;
-	}
+        if (receiveProtocol(i, changeCount)) {
+            // receive succeeded for protocol i
+            break;
+        }
+    }
       repeatCount = 0;
     }
     changeCount = 0;

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -12,6 +12,7 @@
   - Max Horn / max(at)quendi(dot)de
   - Robert ter Vehn / <first name>.<last name>(at)gmail(dot)com
   - Johann Richard / <first name>.<last name>(at)gmail(dot)com
+  - Vlad Gheorghe / <first name>.<last name>(at)gmail(dot)com https://github.com/vgheo
   
   Project home: https://github.com/sui77/rc-switch/
 

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -707,7 +707,7 @@ void RCSwitch::handleInterrupt() {
     repeatCount++;
     changeCount--;
     if (repeatCount == 2) {
-	for(unsigned int i = 1; i < numProto; i++ ) {
+	for(unsigned int i = 1; i <= numProto; i++ ) {
         if (receiveProtocol(i, changeCount)) {
             // receive succeeded for protocol i
             break;


### PR DESCRIPTION
057d : fix inappropriate use of exit to break a for loop 
The use of exit as a keyword has no effect. It is actually a no-effect expression of type pointer-to-function, for the standard function void exit(int).
See https://gist.github.com/vgheo/f34ac7afd6447b3f1fc4 for a test case.

efff : fix off-by-one error in loop over all defined protocols
The protocol identifier is 1-based, hence the full range of protocols is 1..numProto .
receiveProtocol() handles this by subtracting 1 from the protocol id to transform it in a valid index in the proto[] global array.

