### PR TITLE
Fix Travis CI build

### DIFF
--- a/examples/ReceiveDemo_Advanced/output.ino
+++ b/examples/ReceiveDemo_Advanced/output.ino
@@ -1,3 +1,6 @@
+static const char* bin2tristate(const char* bin);
+static char * dec2binWzerofill(unsigned long Dec, unsigned int bitLength);
+
 void output(unsigned long decimal, unsigned int length, unsigned int delay, unsigned int* raw, unsigned int protocol) {
 
   if (decimal == 0) {


### PR DESCRIPTION
The Travis CI builds use platformio which doesn't do the same behind the scenes fix ups that the Arduino IDE does.  It expects forward declarations like standard C/C++.