### PR TITLE
Updated README.md to include HT6P20X

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ or more devices with one of the supported chipsets:
  - PT2262 / PT2272
  - EV1527 / RT1527 / FP1527 / HS1527 
  - Intertechno outlets
+ - HT6P20X
 
 ### Receive and decode RC codes
 


### PR DESCRIPTION
Just a simple fix, to also includes **HT6P20X** chipset in the main README file.

Consider linked to PR https://github.com/sui77/rc-switch/pull/49
