### PR TITLE
Fixes #82: Missing sync on first transmit.

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -496,13 +496,13 @@ void RCSwitch::send(unsigned long code, unsigned int length) {
 #endif
 
   for (int nRepeat = 0; nRepeat < nRepeatTransmit; nRepeat++) {
+    this->transmit(protocol.syncFactor);
     for (int i = length-1; i >= 0; i--) {
       if (code & (1L << i))
         this->transmit(protocol.one);
       else
         this->transmit(protocol.zero);
     }
-    this->transmit(protocol.syncFactor);
   }
 
 #if not defined( RCSwitchDisableReceiving )


### PR DESCRIPTION
#### What's this PR do?
- Fixes an issue with sync (preambule) being sent after first code transmission

#### Testing
I used 2 Arduinos:

1) 433 Mhz receiver that coded to blink when the right code is caught
2) 433 Mhz transmitter that sends the code. I reverse-engineered it from my garage door RC (HS1527 chip)

Then I set `mySwitch.setRepeatTransmit();` on the transmitter (2) to a minimum that the receiver (1) would catch every time, in my case 4 times. When set to 3, receiver (1) couldn't catch it.

After the change receiver (1) starting to catch the code every time with `mySwitch.setRepeatTransmit(3);` set.

#### What are the relevant tickets?
Fixes #82.
