### PR TITLE
Use ring buffer and semaphore

### DIFF
--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -47,6 +47,10 @@
 
 #include <stdint.h>
 
+#if not defined( RCSwitchDisableReceiving )
+  #include <semaphore.h>
+#endif
+
 
 // At least for the ATTiny X4/X5, receiving has to be disabled due to
 // missing libm depencies (udivmodhi4)
@@ -57,6 +61,10 @@
 // Number of maximum High/Low changes per packet.
 // We can handle up to (unsigned long) => 32 bit * 2 H/L changes per bit + 2 for sync
 #define RCSWITCH_MAX_CHANGES 67
+
+#if not defined( RCSwitchDisableReceiving )
+  #define RCSWITCH_MAX_EVENTS 100
+#endif
 
 class RCSwitch {
 
@@ -84,6 +92,8 @@ class RCSwitch {
     void disableReceive();
     bool available();
     void resetAvailable();
+
+    unsigned long popEvent();
 
     unsigned long getReceivedValue();
     unsigned int getReceivedBitlength();
@@ -146,6 +156,13 @@ class RCSwitch {
      * timings[0] contains sync timing, followed by a number of bits
      */
     static unsigned int timings[RCSWITCH_MAX_CHANGES];
+
+    static void pushEvent(unsigned long);
+
+    static unsigned long events[RCSWITCH_MAX_EVENTS];
+    static int eventsHead;
+    static int eventsTail;
+    static sem_t eventSem;
     #endif
 
     


### PR DESCRIPTION
This PR is based on https://github.com/UrbaneChimp/433Utils/commit/3f2517efffd870d571302231380410f3ad431ff1, I only did the porting.

I basically have the issue mentioned in ninjablocks/433Utils#16. @rotv pointed out that there is a fork with a solution which could be applied here (as ninjablocks/433Utils#17 is merged by now). Actually there are a few more forks containing that solution and it appears none has brought it up here.

I tested these changes with a small change to the 433Utils on a raspberry pi: https://github.com/Locke/433Utils/blob/popEvent/RPi_utils/RFSniffer.cpp

My biggest concern is that this pulls in another dependency which might not be available / suited for the Arduino. I can imagine using flags to enable these changes only for the RPI or via a new flag.