### PR TITLE
Add support for fourth tri-state

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -452,6 +452,10 @@ void RCSwitch::sendTriState(const char* sCodeWord) {
         // bit pattern 01
         code |= 1L;
         break;
+      case 'X':
+        // bit pattern 10
+        code |= 2L;
+        break;
       case '1':
         // bit pattern 11
         code |= 3L;


### PR DESCRIPTION
There are some remotes that use a fourth tri-bit (tetra-bit?), e.g. Unitec 50028 / 48110 or Noru remotes. Tested with a Unitec 50028 remote.

See:

* http://tinkerman.cat/decoding-433mhz-rf-data-from-wireless-switches/
* http://tinkerman.cat/decoding-433mhz-rf-data-from-wireless-switches-the-data/