### PR TITLE
Changed order of setProtocol and setPulseLength in SendDemo

### DIFF
--- a/examples/SendDemo/SendDemo.ino
+++ b/examples/SendDemo/SendDemo.ino
@@ -15,12 +15,12 @@ void setup() {
   
   // Transmitter is connected to Arduino Pin #10  
   mySwitch.enableTransmit(10);
-
-  // Optional set pulse length.
-  // mySwitch.setPulseLength(320);
   
   // Optional set protocol (default is 1, will work for most outlets)
   // mySwitch.setProtocol(2);
+
+  // Optional set pulse length.
+  // mySwitch.setPulseLength(320);
   
   // Optional set number of transmission repetitions.
   // mySwitch.setRepeatTransmit(15);


### PR DESCRIPTION
Changed the order of "mySwitch.setProtocol(2);" and "mySwitch.setPulseLength(320);", so setting the PulseLength will work when both lines are commented out.

Fixes sui77/rc-switch#117