### PR TITLE
Add support for SM5212 chips

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -78,7 +78,7 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
   { 100, { 30, 71 }, {  4, 11 }, {  9,  6 }, false },    // protocol 3
   { 380, {  1,  6 }, {  1,  3 }, {  3,  1 }, false },    // protocol 4
   { 500, {  6, 14 }, {  1,  2 }, {  2,  1 }, false },    // protocol 5
-  { 450, { 23,  1 }, {  1,  2 }, {  2,  1 }, true }      // protocol 6 (HT6P20B)
+  { 450, { 23,  1 }, {  1,  2 }, {  2,  1 }, true },     // protocol 6 (HT6P20B)
   { 320, { 36,  1 }, {  1,  2 }, {  2,  1 }, true }      // protocol 7 (SM5212)
 };
 

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -79,6 +79,7 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
   { 380, {  1,  6 }, {  1,  3 }, {  3,  1 }, false },    // protocol 4
   { 500, {  6, 14 }, {  1,  2 }, {  2,  1 }, false },    // protocol 5
   { 450, { 23,  1 }, {  1,  2 }, {  2,  1 }, true }      // protocol 6 (HT6P20B)
+  { 320, { 36,  1 }, {  1,  2 }, {  2,  1 }, true }      // protocol 7 (SM5212)
 };
 
 enum {


### PR DESCRIPTION
I've found some old rf controlled sockets lying around, and got them working by adding a protocol based on this datasheet of the SM5212E IC that they use in the remote:
http://pdf1.alldatasheet.com/datasheet-pdf/view/116988/SAMHOP/SM5212E.html
Hope it helps somebody else struggling with these old devices :)) Btw. they use only 12 bits of data, so you have to remember this ;)