### PR TITLE
Added sending of X state (10 bit sequence) - used in Noru/ORNO remotes

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -452,6 +452,10 @@ void RCSwitch::sendTriState(const char* sCodeWord) {
         // bit pattern 01
         code |= 1L;
         break;
+      case 'X':
+        // bit pattern 10
+        code |= 2L;
+        break;
       case '1':
         // bit pattern 11
         code |= 3L;


### PR DESCRIPTION
This PR adds the capability of sending "X" state (that's bit sequence 10). It is used in some of the remotes like Noru or ORNO.