### PR TITLE
[RFC]Add support for ClassOhlson Nexa remotes

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -73,12 +73,13 @@ static const RCSwitch::Protocol proto[] = {
 #else
 static const RCSwitch::Protocol PROGMEM proto[] = {
 #endif
-  { 350, {  1, 31 }, {  1,  3 }, {  3,  1 }, false },    // protocol 1
-  { 650, {  1, 10 }, {  1,  2 }, {  2,  1 }, false },    // protocol 2
-  { 100, { 30, 71 }, {  4, 11 }, {  9,  6 }, false },    // protocol 3
-  { 380, {  1,  6 }, {  1,  3 }, {  3,  1 }, false },    // protocol 4
-  { 500, {  6, 14 }, {  1,  2 }, {  2,  1 }, false },    // protocol 5
-  { 450, { 23,  1 }, {  1,  2 }, {  2,  1 }, true }      // protocol 6 (HT6P20B)
+  { 350, {  1, 31 }, {  1,  3 }, {  3,  1 }, false, 0 },    // protocol 1
+  { 650, {  1, 10 }, {  1,  2 }, {  2,  1 }, false, 0 },    // protocol 2
+  { 100, { 30, 71 }, {  4, 11 }, {  9,  6 }, false, 0 },    // protocol 3
+  { 380, {  1,  6 }, {  1,  3 }, {  3,  1 }, false, 0 },    // protocol 4
+  { 500, {  6, 14 }, {  1,  2 }, {  2,  1 }, false, 0 },    // protocol 5
+  { 450, { 23,  1 }, {  1,  2 }, {  2,  1 }, true,  0 },    // protocol 6 (HT6P20B)
+  { 220, {  1, 46 }, {  1,  6 }, {  1,  1 }, false, 2 }     // protocol 7 (NEXA)
 };
 
 enum {
@@ -625,7 +626,8 @@ bool RECEIVE_ATTR RCSwitch::receiveProtocol(const int p, unsigned int changeCoun
      *
      * The 2nd saved duration starts the data
      */
-    const unsigned int firstDataTiming = (pro.invertedSignal) ? (2) : (1);
+    const unsigned int firstDataTiming = (pro.invertedSignal) ? (2) : (1)
+                                         + pro.skipPulses;
 
     for (unsigned int i = firstDataTiming; i < changeCount - 1; i += 2) {
         code <<= 1;

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -58,7 +58,7 @@
 
 // Number of maximum High/Low changes per packet.
 // We can handle up to (unsigned long) => 32 bit * 2 H/L changes per bit + 2 for sync
-#define RCSWITCH_MAX_CHANGES 67
+#define RCSWITCH_MAX_CHANGES 133
 
 class RCSwitch {
 
@@ -114,6 +114,7 @@ class RCSwitch {
         HighLow one;
         /** @brief if true inverts the high and low logic levels in the HighLow structs */
         bool invertedSignal;
+        int skipPulses;
     };
 
     void setProtocol(Protocol protocol);


### PR DESCRIPTION
The remotes sold in ClasOhlson in scandinavia have a slightly longer sync sequence(added a skip pulse field in the protocol) and a 64 bit code word. Part of the code gets lost but that seems to be OK until support for 64 bit codes is added.
I'm not quite sure this is the best way to do this, but it's the least amount of code changed.

The output looks like this:
`

Decimal: 2522218496 (65Bit) Binary: 00000000000000000000000000000000010010110010101101101010011010010 Tri-State: not applicable PulseLength: 222 microseconds Protocol: 7
Raw data: 10240,252,2680,256,288,248,1312,248,1300,248,300,248,288,248,1308,252,1304,248,296,248,1300,252,300,248,288,248,1312,248,292,248,1308,252,1304,244,312,248,292,244,1312,248,1304,248,296,248,288,252,1308,252,1304,248,296,248,1304,248,296,248,292,248,1316,244,1304,244,300,248,296,240,1328,244,296,244,1312,248,1304,248,304,240,1308,244,304,244,292,240,1320,244,1308,240,308,240,1312,240,304,240,1316,236,308,236,304,236,1336,236,1312,240,316,228,304,232,1336,224,308,228,1340,220,1324,228,320,228,312,224,1332,228,312,224,1332,228,316,220,1336,224,320,216,1332,

Decimal: 2522245802 (65Bit) Binary: 00000000000000000000000000000000010010110010101101101010011010010 Tri-State: not applicable PulseLength: 222 microseconds Protocol: 7
Raw data: 10272,228,2700,232,308,228,1332,232,1320,228,316,232,304,232,1332,228,1320,232,316,228,1324,228,320,228,308,228,1332,228,312,224,1336,224,1332,220,332,224,316,220,1340,224,1324,224,324,224,316,220,1336,224,1328,224,324,220,1332,220,324,228,308,224,1344,216,1324,228,324,220,316,224,1348,224,312,224,1336,228,1320,228,320,228,1324,228,320,224,312,228,32,1344,256,1140,188,504,60,316,68,224,1324,228,316,232,312,224,1340,232,1324,228,316,232,304,232,1328,232,312,224,1328,236,304,232,1324,236,308,228,1328,236,304,232,1324,236,304,808,1056,520,40,284,56,
`