### PR TITLE
Add C.H.I.P support

### DIFF
--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -34,6 +34,16 @@
     #include "Arduino.h"
 #elif defined(ENERGIA) // LaunchPad, FraunchPad and StellarPad specific
     #include "Energia.h"
+#elif defined(GETCHIP) // C.H.I.P
+    // Include libraries for RPi:
+    #include <string.h> /* memcpy */
+    #include <stdlib.h> /* abs */
+
+    extern "C" {
+      #include "CHIP_IO/source/common.h"
+      #include "CHIP_IO/source/event_gpio.h"
+    }
+
 #elif defined(RPI) // Raspberry Pi
     #define RaspberryPi
 
@@ -156,6 +166,7 @@ class RCSwitch {
     void transmit(HighLow pulses);
 
     #if not defined( RCSwitchDisableReceiving )
+    static void handleInterrupt(int gpio, void* data);
     static void handleInterrupt();
     static bool receiveProtocol(const int p, unsigned int changeCount);
     int nReceiverInterrupt;

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rc-switch
 [![Build Status](https://travis-ci.org/sui77/rc-switch.svg?branch=master)](https://travis-ci.org/sui77/rc-switch)
 
-Use your Arduino or Raspberry Pi to operate remote radio controlled devices
+Use your Arduino, Raspberry Pi or C.H.I.P to operate remote radio controlled devices
 
 ## Download
 https://github.com/sui77/rc-switch/releases/latest
@@ -14,11 +14,11 @@ https://github.com/sui77/rc-switch/wiki
 ## Info
 ### Send RC codes
 
-Use your Arduino or Raspberry Pi to operate remote radio controlled devices.
+Use your Arduino, Raspberry Pi or C.H.I.P to operate remote radio controlled devices.
 This will most likely work with all popular low cost power outlet sockets. If
 yours doesn't work, you might need to adjust the pulse length.
 
-All you need is a Arduino or Raspberry Pi, a 315/433MHz AM transmitter and one
+All you need is a Arduino, Raspberry Pi or C.H.I.P, a 315/433MHz AM transmitter and one
 or more devices with one of the supported chipsets:
 
  - SC5262 / SC5272
@@ -37,5 +37,11 @@ All you need is an Arduino, a 315/433MHz AM receiver (altough there is no
 instruction yet, yes it is possible to hack an existing device) and a remote
 hand set.
 
-For the Raspberry Pi, clone the https://github.com/ninjablocks/433Utils project to
-compile a sniffer tool and transmission commands.
+For the Raspberry Pi, clone the
+https://github.com/ninjablocks/433Utils project to compile a sniffer tool and
+transmission commands.
+
+For the [C.H.I.P](http://getchip.com), clone the
+https://github.com/xtacocorex/CHIP_IO project into this directory for the
+required C libraries, then clone the https://github.com/ninjablocks/433Utils
+project to compile a sniffer tool and transmission commands.


### PR DESCRIPTION
This patch adds support for the CHIP (http://getchip.com) device using the
CHIP_IO libraries.

Note: Depends on https://github.com/xtacocorex/CHIP_IO/pull/70