### PR TITLE
Allow use of PinChangeInterrupt

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -542,7 +542,9 @@ void RCSwitch::enableReceive() {
     RCSwitch::nReceivedBitlength = 0;
 #if defined(RaspberryPi) // Raspberry Pi
     wiringPiISR(this->nReceiverInterrupt, INT_EDGE_BOTH, &handleInterrupt);
-#else // Arduino
+#elif defined(USE_PIN_CHANGE_INTERRUPT)  // Arduino with PinChangeINTerrupt library
+    attachPinChangeInterrupt(this->nReceiverInterrupt, handleInterrupt, CHANGE);
+#else // Arduino with regular INTerrupts
     attachInterrupt(this->nReceiverInterrupt, handleInterrupt, CHANGE);
 #endif
   }
@@ -552,9 +554,13 @@ void RCSwitch::enableReceive() {
  * Disable receiving data
  */
 void RCSwitch::disableReceive() {
-#if not defined(RaspberryPi) // Arduino
+#if defined(RaspberryPi) // Raspberry Pi
+  // For Raspberry Pi (wiringPi) you can't unregister the ISR - do nothing
+#elif defined(USE_PIN_CHANGE_INTERRUPT)  // Arduino with PinChangeINTerrupt library
+  detachPinChangeInterrupt(this->nReceiverInterrupt);
+#else // Arduino with regular INTerrupts
   detachInterrupt(this->nReceiverInterrupt);
-#endif // For Raspberry Pi (wiringPi) you can't unregister the ISR
+#endif 
   this->nReceiverInterrupt = -1;
 }
 

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -50,10 +50,17 @@
 #include <stdint.h>
 
 
-// At least for the ATTiny X4/X5, receiving has to be disabled due to
-// missing libm depencies (udivmodhi4)
-#if defined( __AVR_ATtinyX5__ ) or defined ( __AVR_ATtinyX4__ )
-#define RCSwitchDisableReceiving
+// Enable the following if you would like to use https://github.com/NicoHood/PinChangeInterrupt
+// for handling interrupts. It allows you to select any pin as receiver input, not only D2 and D3.
+//#define USE_PIN_CHANGE_INTERRUPT
+
+
+#ifdef USE_PIN_CHANGE_INTERRUPT
+    #include <PinChangeInterrupt.h> // https://github.com/NicoHood/PinChangeInterrupt
+#else
+    #if defined( __AVR_ATtinyX5__ ) or defined ( __AVR_ATtinyX4__ )
+    #define RCSwitchDisableReceiving
+    #endif
 #endif
 
 // Number of maximum high/Low changes per packet.


### PR DESCRIPTION
...with the PinChangeInterrupt library by @NicoHood

This allows to enable reception for ATtinyX4 and ATtinyX5, as well
as on other chips selecting any pin as receiver input, not only
D2 and D3.

This is a adapted version of https://github.com/sui77/rc-switch/pull/59
by @cyosp, taking into account the comments by @fingolfin