### PR TITLE
Send a free sequence of pulses with custom timings

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -484,6 +484,34 @@ void RCSwitch::send(const char* sCodeWord) {
  * then the bit at position length-2, and so on, till finally the bit at position 0.
  */
 void RCSwitch::send(unsigned long code, unsigned int length) {
+
+  // if there is a pointer to a transmit timings array, write the timings to
+  // the array instead of sending them.
+  // allways start with low signal. Do not send (return).
+  // the host program is completely responsible for the array memory management
+  if (transmittimings){
+    int invertedoffset = 0;
+    if (this->protocol.invertedSignal) invertedoffset = 1;
+    for (int i = length-1; i >= 0; i--) {
+      if (code & (1L << i)) {
+        transmittimings[2*(length-i-1)+1+invertedoffset] = this->protocol.pulseLength * this->protocol.one.high;
+        transmittimings[2*(length-i-1)+1+invertedoffset+1] = this->protocol.pulseLength * this->protocol.one.low;
+      } else {
+        transmittimings[2*(length-i-1)+1+invertedoffset] = this->protocol.pulseLength * this->protocol.zero.high;
+        transmittimings[2*(length-i-1)+1+invertedoffset+1] = this->protocol.pulseLength * this->protocol.zero.low;
+      }
+    }
+    if (this->protocol.invertedSignal) {
+      transmittimings[0] = this->protocol.pulseLength * this->protocol.syncFactor.high;
+      transmittimings[1] = this->protocol.pulseLength * this->protocol.syncFactor.low;
+    } else {
+      transmittimings[2*length+1] = this->protocol.pulseLength * this->protocol.syncFactor.high;
+      transmittimings[0] = this->protocol.pulseLength * this->protocol.syncFactor.low;
+    }
+    transmittimings[2*length+2] = 0; // zero-terminate the array
+    return;
+    }
+
   if (this->nTransmitterPin == -1)
     return;
 
@@ -503,6 +531,47 @@ void RCSwitch::send(unsigned long code, unsigned int length) {
         this->transmit(protocol.zero);
     }
     this->transmit(protocol.syncFactor);
+  }
+
+#if not defined( RCSwitchDisableReceiving )
+  // enable receiver again if we just disabled it
+  if (nReceiverInterrupt_backup != -1) {
+    this->enableReceive(nReceiverInterrupt_backup);
+  }
+#endif
+}
+
+/**
+ * Transmit signal with the timings stored in transmittimings zero-terminated integrer array
+ * until a 0 timing is found or the RCSWITCH_MAX_CHANGES is reached
+ * first timing is always low. A final low is always sent in case the number of timings is not even
+ * the host program is completely responsible for the array memory management
+ */
+void RCSwitch::send(unsigned int * ptrtransmittimings) {
+  if (this->nTransmitterPin == -1)
+    return;
+
+  if (!ptrtransmittimings)
+    return;
+
+#if not defined( RCSwitchDisableReceiving )
+  // make sure the receiver is disabled while we transmit
+  int nReceiverInterrupt_backup = nReceiverInterrupt;
+  if (nReceiverInterrupt_backup != -1) {
+    this->disableReceive();
+  }
+#endif
+
+  for (int nRepeat = 0; nRepeat < nRepeatTransmit; nRepeat++) {
+    unsigned int currenttiming = 0;
+    bool currentlogiclevel = false;
+    while( ptrtransmittimings[currenttiming] && currenttiming < RCSWITCH_MAX_CHANGES ) {
+      digitalWrite(this->nTransmitterPin, currentlogiclevel ? HIGH : LOW);
+      delayMicroseconds( ptrtransmittimings[currenttiming] );
+      currenttiming++;
+      currentlogiclevel = !currentlogiclevel;
+    }
+  digitalWrite(this->nTransmitterPin, LOW);
   }
 
 #if not defined( RCSwitchDisableReceiving )

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -79,6 +79,8 @@ class RCSwitch {
     void sendTriState(const char* sCodeWord);
     void send(unsigned long code, unsigned int length);
     void send(const char* sCodeWord);
+    void send(unsigned int * ptrtransmittimings);
+    unsigned int * transmittimings = NULL; // this should have a get/set functions interface
     
     #if not defined( RCSwitchDisableReceiving )
     void enableReceive(int interrupt);


### PR DESCRIPTION
This is an extension that does not break current API. The change increases the footprint of the program just a little with minimal impact on memory use on runtime.

It allows to send a free sequence of pulses with custom timings.
It also allows to generate such sequences from command functions.

This is the functionality that this API extension adds:
- Use `send(unsigned int *)` to send a starting-low zero-terminated array of timings.
- Create an array of timings: If pointer `transmittimings` is not null any send command saves the timings to the pointed array instead of sending the code (the main program is responsible from memory management and coherent function calling that will not cause a buffer overflow).

These modification tries to be as small as possible. Error checking has been left out.

A full explanation is in: https://github.com/sui77/rc-switch/issues/146

An example and small tutorial on how to use the custom timings send function: https://github.com/sui77/rc-switch/issues/163#issuecomment-330576310

There are several issues asking for this functionality. Also issue https://github.com/sui77/rc-switch/issues/163 proves that there is demand and possible uses for this modification.

NOTE: This is an API compatible modification. I believe that the next major version advance of the library (new API) could implement a layered architecture ranging from functions to deal with brand/command to those managing low level control of the transmitter. I will open an issue with these ideas at some point or we could discuss them through email.