### PR TITLE
Add support for HS2303-PT

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -78,7 +78,8 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
   { 100, { 30, 71 }, {  4, 11 }, {  9,  6 }, false },    // protocol 3
   { 380, {  1,  6 }, {  1,  3 }, {  3,  1 }, false },    // protocol 4
   { 500, {  6, 14 }, {  1,  2 }, {  2,  1 }, false },    // protocol 5
-  { 450, { 23,  1 }, {  1,  2 }, {  2,  1 }, true }      // protocol 6 (HT6P20B)
+  { 450, { 23,  1 }, {  1,  2 }, {  2,  1 }, true },      // protocol 6 (HT6P20B)
+  { 150, {  2, 62 }, {  1,  6 }, {  6,  1 }, false }     // protocol 7 (HS2303-PT, i. e. used in AUKEY Remote)
 };
 
 enum {


### PR DESCRIPTION
Add support for the HS2303-PT chip as protocol 7. I've found such a chip in an AUKEY remote like this:

https://www.amazon.de/Funksteckdose-Programmierbarer-Steckdosenschalter-Haushaltsger%C3%A4te-Betriebsbereich/dp/B01GCTLSW6/ref=sr_1_1?ie=UTF8&qid=1509360644&sr=8-1&keywords=aukey+funksteckdosen

Protocol one worked, but was unreliable. I've analysed the signal timing and figured out that it was close to procotol 1, but didn't match exactly, so I've improved the timing.

Small warning: If you can avoid those RC outlets. They do work, but the relays have a very limited lifecycle (= they break fast).