### PR TITLE
Remove unnecessary conditions from examples

### DIFF
--- a/examples/ReceiveDemo_Advanced/output.ino
+++ b/examples/ReceiveDemo_Advanced/output.ino
@@ -3,24 +3,20 @@ static char * dec2binWzerofill(unsigned long Dec, unsigned int bitLength);
 
 void output(unsigned long decimal, unsigned int length, unsigned int delay, unsigned int* raw, unsigned int protocol) {
 
-  if (decimal == 0) {
-    Serial.print("Unknown encoding.");
-  } else {
-    const char* b = dec2binWzerofill(decimal, length);
-    Serial.print("Decimal: ");
-    Serial.print(decimal);
-    Serial.print(" (");
-    Serial.print( length );
-    Serial.print("Bit) Binary: ");
-    Serial.print( b );
-    Serial.print(" Tri-State: ");
-    Serial.print( bin2tristate( b) );
-    Serial.print(" PulseLength: ");
-    Serial.print(delay);
-    Serial.print(" microseconds");
-    Serial.print(" Protocol: ");
-    Serial.println(protocol);
-  }
+  const char* b = dec2binWzerofill(decimal, length);
+  Serial.print("Decimal: ");
+  Serial.print(decimal);
+  Serial.print(" (");
+  Serial.print( length );
+  Serial.print("Bit) Binary: ");
+  Serial.print( b );
+  Serial.print(" Tri-State: ");
+  Serial.print( bin2tristate( b) );
+  Serial.print(" PulseLength: ");
+  Serial.print(delay);
+  Serial.print(" microseconds");
+  Serial.print(" Protocol: ");
+  Serial.println(protocol);
   
   Serial.print("Raw data: ");
   for (unsigned int i=0; i<= length*2; i++) {

--- a/examples/ReceiveDemo_Simple/ReceiveDemo_Simple.ino
+++ b/examples/ReceiveDemo_Simple/ReceiveDemo_Simple.ino
@@ -16,19 +16,13 @@ void setup() {
 void loop() {
   if (mySwitch.available()) {
     
-    int value = mySwitch.getReceivedValue();
-    
-    if (value == 0) {
-      Serial.print("Unknown encoding");
-    } else {
-      Serial.print("Received ");
-      Serial.print( mySwitch.getReceivedValue() );
-      Serial.print(" / ");
-      Serial.print( mySwitch.getReceivedBitlength() );
-      Serial.print("bit ");
-      Serial.print("Protocol: ");
-      Serial.println( mySwitch.getReceivedProtocol() );
-    }
+    Serial.print("Received ");
+    Serial.print( mySwitch.getReceivedValue() );
+    Serial.print(" / ");
+    Serial.print( mySwitch.getReceivedBitlength() );
+    Serial.print("bit ");
+    Serial.print("Protocol: ");
+    Serial.println( mySwitch.getReceivedProtocol() );
 
     mySwitch.resetAvailable();
   }


### PR DESCRIPTION
The condition `if (mySwitch.getReceivedValue == 0)` wrapped in the condition `if (mySwitch.available())` in receive examples is not necessary, because the `RCSwitch::available()` function is true only if `RCSwitch::nReceivedValue != 0` and  `RCSwitch::getReceivedValue()` returns the `RCSwitch::nReceivedValue`, thus `mySwitch.getReceivedValue` is in this case always non-zero.