### PR TITLE
Fix for ESP32: if nReceiverInterrupt is -1, dont detachInterrupt in d…

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -556,10 +556,12 @@ void RCSwitch::enableReceive() {
  * Disable receiving data
  */
 void RCSwitch::disableReceive() {
+  if (this->nReceiverInterrupt != -1) {
 #if not defined(RaspberryPi) // Arduino
   detachInterrupt(this->nReceiverInterrupt);
 #endif // For Raspberry Pi (wiringPi) you can't unregister the ISR
   this->nReceiverInterrupt = -1;
+}
 }
 
 bool RCSwitch::available() {


### PR DESCRIPTION
…isableReceive.

detachInterrupt(-1) locks the ESP32 and triggers the watchdog.