### PR TITLE
RX debug

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -78,7 +78,7 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
   { 100, { 30, 71 }, {  4, 11 }, {  9,  6 }, false },    // protocol 3
   { 380, {  1,  6 }, {  1,  3 }, {  3,  1 }, false },    // protocol 4
   { 500, {  6, 14 }, {  1,  2 }, {  2,  1 }, false },    // protocol 5
-  { 450, { 23,  1 }, {  1,  2 }, {  2,  1 }, true },      // protocol 6 (HT6P20B)
+  { 450, { 23,  1 }, {  1,  2 }, {  2,  1 }, true  },    // protocol 6 (HT6P20B)
   { 150, {  2, 62 }, {  1,  6 }, {  6,  1 }, false }     // protocol 7 (HS2303-PT, i. e. used in AUKEY Remote)
 };
 
@@ -677,6 +677,7 @@ void RECEIVE_ATTR RCSwitch::handleInterrupt() {
       // with roughly the same gap between them).
       repeatCount++;
       if (repeatCount == 2) {
+        if (onRxBufferDebug) onRxBufferDebug(changeCount, RCSwitch::timings);
         for(unsigned int i = 1; i <= numProto; i++) {
           if (receiveProtocol(i, changeCount)) {
             // receive succeeded for protocol i
@@ -698,4 +699,7 @@ void RECEIVE_ATTR RCSwitch::handleInterrupt() {
   RCSwitch::timings[changeCount++] = duration;
   lastTime = time;  
 }
+
+void (*RCSwitch::onRxBufferDebug)(int, unsigned int*) = NULL;
+
 #endif

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -47,6 +47,8 @@
     #include "WProgram.h"
 #endif
 
+#define HAS_RC_ONRXBUFFER
+
 #include <stdint.h>
 
 
@@ -58,7 +60,7 @@
 
 // Number of maximum high/Low changes per packet.
 // We can handle up to (unsigned long) => 32 bit * 2 H/L changes per bit + 2 for sync
-#define RCSWITCH_MAX_CHANGES 67
+#define RCSWITCH_MAX_CHANGES 131
 
 class RCSwitch {
 
@@ -176,9 +178,13 @@ class RCSwitch {
      * timings[0] contains sync timing, followed by a number of bits
      */
     static unsigned int timings[RCSWITCH_MAX_CHANGES];
+
+    #ifdef HAS_RC_ONRXBUFFER
+    public:
+    static void (*onRxBufferDebug)(int count, unsigned int *timings);
     #endif
 
-    
+    #endif
 };
 
 #endif


### PR DESCRIPTION
Hi, this is a patch to add a diagnostic point in rc-switch.

* It adds a callback, `void (*RCSwitch::onRxBufferDebug)(int count, unsigned int* timings)` that library clients can set to a user-side debug function, to receive timing buffer data whenever a decoding is attempted.
* It also adds a #define, `HAS_RC_ONRXBUFFER`, which signals to the code using the library that the hook is available.

The change is silent until the hook is callback and, when idle, it has a very minimum impact on performance.