### PR TITLE
Add protocol for Arlec R210 switches

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -79,7 +79,8 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
   { 380, {  1,  6 }, {  1,  3 }, {  3,  1 }, false },    // protocol 4
   { 500, {  6, 14 }, {  1,  2 }, {  2,  1 }, false },    // protocol 5
   { 450, { 23,  1 }, {  1,  2 }, {  2,  1 }, true },      // protocol 6 (HT6P20B)
-  { 150, {  2, 62 }, {  1,  6 }, {  6,  1 }, false }     // protocol 7 (HS2303-PT, i. e. used in AUKEY Remote)
+  { 150, {  2, 62 }, {  1,  6 }, {  6,  1 }, false },    // protocol 7 (HS2303-PT, i. e. used in AUKEY Remote)
+  { 385, {  1, 17 }, {  1,  2 }, {  2,  1 }, false }     // protocol 8 (Arlec RC210; see details in the wiki)
 };
 
 enum {


### PR DESCRIPTION
This pull request adds the protocol for Arlec R210 switches as decoded by @Martin-Laclaustra here:

* https://github.com/sui77/rc-switch/issues/242#issuecomment-403633261

Note that there is more detail on these switches in the wiki at:

* [Description of socket protocols from different brands and models](https://github.com/sui77/rc-switch/wiki/Description-of-socket-protocols-from-different-brands-and-models#arlec-rc210-aunz-240v-socket-remote-controlled-power-outlets).