### PR TITLE
Solved warnings so that compilation with g++ -Werror=conversion and -Werror=switch-default is possible.

### DIFF
--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -96,7 +96,7 @@ class RCSwitch {
   
     void enableTransmit(int nTransmitterPin);
     void disableTransmit();
-    void setPulseLength(int nPulseLength);
+    void setPulseLength(uint16_t nPulseLength);
     void setRepeatTransmit(int nRepeatTransmit);
     #if not defined( RCSwitchDisableReceiving )
     void setReceiveTolerance(int nPercent);
@@ -146,7 +146,7 @@ class RCSwitch {
 
     void setProtocol(Protocol protocol);
     void setProtocol(int nProtocol);
-    void setProtocol(int nProtocol, int nPulseLength);
+    void setProtocol(int nProtocol, uint16_t nPulseLength);
 
   private:
     char* getCodeWordA(const char* sGroup, const char* sDevice, bool bStatus);


### PR DESCRIPTION
Solved warnings so that compilation with g++ -Werror=conversion and -Werror=switch-default is possible.

With these changes, compilation with g++ treating warnings as errors is possible. To my understanding, the warnings are relevant (e.g. possible integer overflow). 

Note: This changes modify the external interfaces since I did not want to change "struct Protocol". This will introduce a conversion-warning for users which still use the old types in there code. But these users evidently have conversion-warnings disabled since otherwise they would not be able to compile rc-switch without these changes in the first place.

Please review if you agree with my correction suggestion.
