### PR TITLE
improve speed of interrupt handler

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -651,16 +651,12 @@ bool RECEIVE_ATTR RCSwitch::receiveProtocol(const int p, unsigned int changeCoun
             return false;
         }
     }
-
-    if (changeCount > 7) {    // ignore very short transmissions: no device sends them, so this must be noise
-        RCSwitch::nReceivedValue = code;
-        RCSwitch::nReceivedBitlength = (changeCount - 1) / 2;
-        RCSwitch::nReceivedDelay = delay;
-        RCSwitch::nReceivedProtocol = p;
-        return true;
-    }
-
-    return false;
+  
+    RCSwitch::nReceivedValue = code;
+    RCSwitch::nReceivedBitlength = (changeCount - 1) / 2;
+    RCSwitch::nReceivedDelay = delay;
+    RCSwitch::nReceivedProtocol = p;
+    return true;
 }
 
 void RECEIVE_ATTR RCSwitch::handleInterrupt() {
@@ -682,7 +678,7 @@ void RECEIVE_ATTR RCSwitch::handleInterrupt() {
       // here that a sender will send the signal multiple times,
       // with roughly the same gap between them).
       repeatCount++;
-      if (repeatCount == 2) {
+      if (repeatCount == 2 && changeCount > 7) { // ignore very short transmissions: no device sends them, so this must be noise
         for(unsigned int i = 1; i <= numProto; i++) {
           if (receiveProtocol(i, changeCount)) {
             // receive succeeded for protocol i

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -156,8 +156,8 @@ class RCSwitch {
     void transmit(HighLow pulses);
 
     #if not defined( RCSwitchDisableReceiving )
-    static void handleInterrupt();
-    static bool receiveProtocol(const int p, unsigned int changeCount);
+    void handleInterrupt();
+    bool receiveProtocol(const int p, unsigned int changeCount);
     int nReceiverInterrupt;
     #endif
     int nTransmitterPin;
@@ -166,16 +166,22 @@ class RCSwitch {
     Protocol protocol;
 
     #if not defined( RCSwitchDisableReceiving )
-    static int nReceiveTolerance;
-    volatile static unsigned long nReceivedValue;
-    volatile static unsigned int nReceivedBitlength;
-    volatile static unsigned int nReceivedDelay;
-    volatile static unsigned int nReceivedProtocol;
+    int nReceiveTolerance;
+    volatile unsigned long nReceivedValue;
+    volatile unsigned int nReceivedBitlength;
+    volatile unsigned int nReceivedDelay;
+    volatile unsigned int nReceivedProtocol;
     const static unsigned int nSeparationLimit;
+	/*
+	 * Required values for interrupt handler
+	 */
+	unsigned int changeCount = 0;
+	unsigned long lastTime = 0;
+	unsigned int repeatCount = 0;
     /* 
      * timings[0] contains sync timing, followed by a number of bits
      */
-    static unsigned int timings[RCSWITCH_MAX_CHANGES];
+    unsigned int timings[RCSWITCH_MAX_CHANGES];
     #endif
 
     

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Operate 433/315Mhz devices.
 paragraph=Use your Arduino, ESP8266/ESP32 or Raspberry Pi to operate remote radio controlled devices. This will most likely work with all popular low cost power outlet sockets. 
 category=Device Control
 url=https://github.com/sui77/rc-switch
-architectures=avr,esp8266,esp32
+architectures=avr,esp8266,esp32,stm32
 includes=RCSwitch.h


### PR DESCRIPTION
move changeCount check to interrupt handler main routine in order to reduce overhead of calculations in the receiveProtocol() function.