### PR TITLE
enable proper multi instances of rc-switch + improved interrupt routine speed

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -565,8 +565,9 @@ void RCSwitch::enableReceive() {
 #elif defined(STM32_CORE_VERSION)
 	attachInterrupt(this->nReceiverInterrupt, std::bind(&RCSwitch::handleInterrupt, this), CHANGE);
 #else // Arduino	
-	//attachInterrupt(this->nReceiverInterrupt, [this](){ this->handleInterrupt(); }, CHANGE);
-	#error not supported
+	attachInterrupt(this->nReceiverInterrupt, &RCSwitch::handleInterrupt, CHANGE);
+	//attachInterrupt(this->nReceiverInterrupt, handleInterrupt, CHANGE);
+	//#error not supported
 #endif
   }
 }

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -651,16 +651,12 @@ bool RECEIVE_ATTR RCSwitch::receiveProtocol(const int p, unsigned int changeCoun
             return false;
         }
     }
-
-    if (changeCount > 7) {    // ignore very short transmissions: no device sends them, so this must be noise
-        RCSwitch::nReceivedValue = code;
-        RCSwitch::nReceivedBitlength = (changeCount - 1) / 2;
-        RCSwitch::nReceivedDelay = delay;
-        RCSwitch::nReceivedProtocol = p;
-        return true;
-    }
-
-    return false;
+  
+    RCSwitch::nReceivedValue = code;
+    RCSwitch::nReceivedBitlength = (changeCount - 1) / 2;
+    RCSwitch::nReceivedDelay = delay;
+    RCSwitch::nReceivedProtocol = p;
+    return true;
 }
 
 void RECEIVE_ATTR RCSwitch::handleInterrupt() {
@@ -682,7 +678,7 @@ void RECEIVE_ATTR RCSwitch::handleInterrupt() {
       // here that a sender will send the signal multiple times,
       // with roughly the same gap between them).
       repeatCount++;
-      if (repeatCount == 2) {
+      if (repeatCount == 2 && changeCount > 7) { // ignore very short transmissions: no device sends them, so this must be noise
         for(unsigned int i = 1; i <= numProto; i++) {
           if (receiveProtocol(i, changeCount)) {
             // receive succeeded for protocol i

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -156,7 +156,11 @@ class RCSwitch {
     void transmit(HighLow pulses);
 
     #if not defined( RCSwitchDisableReceiving )
+	#if defined(ARDUINO_ARCH_RP2040)
+	static void handleInterrupt(void*);
+	#else
     void handleInterrupt();
+	#endif
     bool receiveProtocol(const int p, unsigned int changeCount);
     int nReceiverInterrupt;
     #endif

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -156,8 +156,8 @@ class RCSwitch {
     void transmit(HighLow pulses);
 
     #if not defined( RCSwitchDisableReceiving )
-    static void handleInterrupt();
-    static bool receiveProtocol(const int p, unsigned int changeCount);
+    void handleInterrupt();
+    bool receiveProtocol(const int p, unsigned int changeCount);
     int nReceiverInterrupt;
     #endif
     int nTransmitterPin;
@@ -166,16 +166,22 @@ class RCSwitch {
     Protocol protocol;
 
     #if not defined( RCSwitchDisableReceiving )
-    static int nReceiveTolerance;
-    volatile static unsigned long nReceivedValue;
-    volatile static unsigned int nReceivedBitlength;
-    volatile static unsigned int nReceivedDelay;
-    volatile static unsigned int nReceivedProtocol;
+    int nReceiveTolerance;
+    volatile unsigned long nReceivedValue;
+    volatile unsigned int nReceivedBitlength;
+    volatile unsigned int nReceivedDelay;
+    volatile unsigned int nReceivedProtocol;
     const static unsigned int nSeparationLimit;
+	/*
+	 * Required values for interrupt handler
+	 */
+	unsigned int changeCount = 0;
+	unsigned long lastTime = 0;
+	unsigned int repeatCount = 0;
     /* 
      * timings[0] contains sync timing, followed by a number of bits
      */
-    static unsigned int timings[RCSWITCH_MAX_CHANGES];
+    unsigned int timings[RCSWITCH_MAX_CHANGES];
     #endif
 
     

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+#This library compiles for STM32 and RP2040 but not Arduino AVR like Nano
+to add support one has to figure out how to pass a non-static class member with `this` object to the attachInterupt
+function.
+other repos for future reference
+https://github.com/maniacbug/StandardCplusplus
+https://github.com/kekyo/BoostForArduino
+https://github.com/vancegroup/arduino-boost
+https://github.com/Stivius/callable-wrapper
+https://github.com/fopeczek/function_objects
+https://github.com/danyhm/functional
+I could get std::bind to work on Arduino Nano however I can't convert it back to c style function pointer.
+It seems it's possible to do it using boost library. however i couldn't get it to compile on Arduino.
+another method is to change Arduino Core files to implement attachInterruptEx or attachInterruptParam
+
 # rc-switch
 [![arduino-library-badge](https://www.ardu-badge.com/badge/rc-switch.svg?)](https://www.ardu-badge.com/rc-switch)
 [![Build Status](https://travis-ci.org/sui77/rc-switch.svg?branch=master)](https://travis-ci.org/sui77/rc-switch)

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Operate 433/315Mhz devices.
 paragraph=Use your Arduino, ESP8266/ESP32 or Raspberry Pi to operate remote radio controlled devices. This will most likely work with all popular low cost power outlet sockets. 
 category=Device Control
 url=https://github.com/sui77/rc-switch
-architectures=avr,esp8266,esp32
+architectures=avr,esp8266,esp32,stm32
 includes=RCSwitch.h


### PR DESCRIPTION
this PR enables multi instances of RC-switch where usage of more than 1 RC module in one sketch is possible (ie. 433 + 315)

fix #345 