### PR TITLE
Use DRAM for ESP32 protocol list

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -41,12 +41,17 @@
     #define memcpy_P(dest, src, num) memcpy((dest), (src), (num))
 #endif
 
-#if defined(ESP8266) || defined(ESP32)
+#if defined(ESP8266)
     // interrupt handler and related code must be in RAM on ESP8266,
     // according to issue #46.
     #define RECEIVE_ATTR ICACHE_RAM_ATTR
+    #define VAR_ISR_ATTR
+#elif defined(ESP32)
+    #define RECEIVE_ATTR IRAM_ATTR
+    #define VAR_ISR_ATTR DRAM_ATTR
 #else
     #define RECEIVE_ATTR
+    #define VAR_ISR_ATTR
 #endif
 
 
@@ -70,7 +75,7 @@
  * These are combined to form Tri-State bits when sending or receiving codes.
  */
 #if defined(ESP8266) || defined(ESP32)
-static const RCSwitch::Protocol proto[] = {
+static const VAR_ISR_ATTR RCSwitch::Protocol proto[] = {
 #else
 static const RCSwitch::Protocol PROGMEM proto[] = {
 #endif


### PR DESCRIPTION
And replace ICACHE_RAM_ATTR by IRAM_ATTR for ESP32, so as to avoir core dump when using in conjunction with Wifi
https://github.com/1technophile/OpenMQTTGateway/issues/620