### PR TITLE
Adding support for Home NetWerks bathroom fan

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -91,7 +91,7 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
   { 365, { 18,  1 }, {  3,  1 }, {  1,  3 }, true },     // protocol 10 (1ByOne Doorbell)
   { 270, { 36,  1 }, {  1,  2 }, {  2,  1 }, true },     // protocol 11 (HT12E)
   { 320, { 36,  1 }, {  1,  2 }, {  2,  1 }, true },     // protocol 12 (SM5212)
-  { 250, { 20, 10 }, {  1,  1 }, {  3,  1 }, false },    // protocol 13 (Home NetWerks Bathroom Fan Model 6201-500)
+  { 250, { 20, 10 }, {  1,  1 }, {  3,  1 }, false }     // protocol 13 (Home NetWerks Bathroom Fan Model 6201-500)
 };
 
 enum {

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -90,7 +90,8 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
   { 200, { 130, 7 }, {  16, 7 }, { 16,  3 }, true},      // protocol 9 Conrad RS-200 TX
   { 365, { 18,  1 }, {  3,  1 }, {  1,  3 }, true },     // protocol 10 (1ByOne Doorbell)
   { 270, { 36,  1 }, {  1,  2 }, {  2,  1 }, true },     // protocol 11 (HT12E)
-  { 320, { 36,  1 }, {  1,  2 }, {  2,  1 }, true }      // protocol 12 (SM5212)
+  { 320, { 36,  1 }, {  1,  2 }, {  2,  1 }, true },     // protocol 12 (SM5212)
+  { 250, { 20, 10 }, {  1,  1 }, {  3,  1 }, false },    // protocol 13 (Home NetWerks Bathroom Fan Model 6201-500)
 };
 
 enum {


### PR DESCRIPTION
I reverse engineered the RF signals used by the remote control on my Home NetWerks Bathroom Fan and it uses a different pulse pattern than what is available in rc-switch so I added a new protocol 13 to support it. This is the bathroom fan: http://www.homenetwerks.com/products/bluetooth-bath-fan-with-LED-light.aspx