### PR TITLE
Add support for receiving HT45F23A, i.e. used in Cordes CC-80, VisorTech RWM-460.f

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ or more devices with one of the supported chipsets:
  - EV1527 / RT1527 / FP1527 / HS1527 
  - Intertechno outlets
  - HT6P20X
+ - HT45F23A (receiver only, needs 'strip stop bits' patch/workaround)
 
 ### Receive and decode RC codes
 


### PR DESCRIPTION
This PR adds receive support for HT45F23A-based smoked detectors.

It includes a patch (workaround) to strip two short "stop bits" at the end of the data telegram. Because of this workaround, this PR is **not** meant to be included in the main source tree. It's just for information, maybe it is useful for someone. You can safely close this PR now :)