### PR TITLE
Receive repeat is configurable

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -103,6 +103,7 @@ volatile unsigned int RCSwitch::nReceivedBitlength = 0;
 volatile unsigned int RCSwitch::nReceivedDelay = 0;
 volatile unsigned int RCSwitch::nReceivedProtocol = 0;
 int RCSwitch::nReceiveTolerance = 60;
+int RCSwitch::nReceiveRepeat = 2;
 const unsigned int RCSwitch::nSeparationLimit = 4300;
 // separationLimit: minimum microseconds between received codes, closer codes are ignored.
 // according to discussion on issue #14 it might be more suitable to set the separation
@@ -117,6 +118,7 @@ RCSwitch::RCSwitch() {
   #if not defined( RCSwitchDisableReceiving )
   this->nReceiverInterrupt = -1;
   this->setReceiveTolerance(60);
+  this->setReceiveRepeat(2);
   RCSwitch::nReceivedValue = 0;
   #endif
 }
@@ -171,6 +173,9 @@ void RCSwitch::setRepeatTransmit(int nRepeatTransmit) {
 #if not defined( RCSwitchDisableReceiving )
 void RCSwitch::setReceiveTolerance(int nPercent) {
   RCSwitch::nReceiveTolerance = nPercent;
+}
+void RCSwitch::setReceiveRepeat(int nCount){
+  RCSwitch::nReceiveRepeat = nCount;
 }
 #endif
   
@@ -687,7 +692,7 @@ void RECEIVE_ATTR RCSwitch::handleInterrupt() {
       // here that a sender will send the signal multiple times,
       // with roughly the same gap between them).
       repeatCount++;
-      if (repeatCount == 2) {
+      if (repeatCount == RCSwitch::nReceiveRepeat) {
         for(unsigned int i = 1; i <= numProto; i++) {
           if (receiveProtocol(i, changeCount)) {
             // receive succeeded for protocol i

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -100,6 +100,7 @@ class RCSwitch {
     void setRepeatTransmit(int nRepeatTransmit);
     #if not defined( RCSwitchDisableReceiving )
     void setReceiveTolerance(int nPercent);
+    void setReceiveRepeat(int nCount);
     #endif
 
     /**
@@ -167,6 +168,7 @@ class RCSwitch {
 
     #if not defined( RCSwitchDisableReceiving )
     static int nReceiveTolerance;
+    static int nReceiveRepeat;
     volatile static unsigned long nReceivedValue;
     volatile static unsigned int nReceivedBitlength;
     volatile static unsigned int nReceivedDelay;


### PR DESCRIPTION
The receive repeat count was hardcoded to 2, this change makes the receive repeat configurable at runtime similar to receive tolerance.  The default value is 2 with a method to override the default.

Reasoning:  In my use case setting repeat to 1 helped receiver reliability.  There may be other use cases where a setting greater than 2 may be useful.