### PR TITLE
Recevier improvements - setReceiveUsingProtocolTiming() and setReceiveUnknownProtocol() 

### DIFF
--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -100,6 +100,8 @@ class RCSwitch {
     void setRepeatTransmit(int nRepeatTransmit);
     #if not defined( RCSwitchDisableReceiving )
     void setReceiveTolerance(int nPercent);
+    void setReceiveUsingProtocolTiming(bool useProtocolTiming);
+    void setReceiveUnknownProtocol(bool showUnknownProtocol);
     #endif
 
     /**
@@ -158,6 +160,7 @@ class RCSwitch {
     #if not defined( RCSwitchDisableReceiving )
     static void handleInterrupt();
     static bool receiveProtocol(const int p, unsigned int changeCount);
+    static void acceptUnknownProtocol(unsigned int changeCount);
     int nReceiverInterrupt;
     #endif
     int nTransmitterPin;
@@ -167,6 +170,8 @@ class RCSwitch {
 
     #if not defined( RCSwitchDisableReceiving )
     static int nReceiveTolerance;
+    static bool receiveUsingProtocolTiming;
+    static bool receiveUnknownProtocol;
     volatile static unsigned long nReceivedValue;
     volatile static unsigned int nReceivedBitlength;
     volatile static unsigned int nReceivedDelay;

--- a/examples/ReceiveDemo_Advanced/ReceiveDemo_Advanced.ino
+++ b/examples/ReceiveDemo_Advanced/ReceiveDemo_Advanced.ino
@@ -14,6 +14,12 @@ RCSwitch mySwitch = RCSwitch();
 void setup() {
   Serial.begin(9600);
   mySwitch.enableReceive(0);  // Receiver on interrupt 0 => that is pin #2
+  // for some transmitters it gives better results when you set it to true
+  // when it is false library is using initial synchronization pulse to determine timing for decoding signal
+  // when it is true library is using protocol definition to determine timing for decoding signal
+  mySwitch.setReceiveUsingProtocolTiming(false);
+  // this is for testing only - it will show timings of received data even, if it doesn't follow any protocol.
+  mySwitch.setReceiveUnknownProtocol(true);
 }
 
 void loop() {


### PR DESCRIPTION

* setReceiveUsingProtocolTiming()

This library is using initial synchronisation pulse to determine base delay value used for decoding data. Some cheap transmitters use slightly shorter synchronisation pulse and, as a result, system is unable to recognize the data sent. 

Setting setReceiveUsingProtocolTiming(**true**) tells library to use standard delay for protocol (e.g. 350 microseconds for protocol 1) to decode input. 
This makes receiver more robust - able to receive data that otherwise was ignored.

* setReceiveUnknownProtocol()

This is used as **debugging aid only**. 
When system is unable to recognize any valid protocol it produces no output. It is difficult to tell is system diidn't receive any data or was unable to decode it. 
With setReceiveUnknownProtocol(**true**) you can see the dump of timers even if no valid protocol was recognized. The `ReceiveDemo_Advanced` example was updated to use it. 


