### PR TITLE
Send the syncFactor before the data

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -508,13 +508,13 @@ void RCSwitch::send(unsigned long code, unsigned int length) {
 #endif
 
   for (int nRepeat = 0; nRepeat < nRepeatTransmit; nRepeat++) {
+    this->transmit(protocol.syncFactor);
     for (int i = length-1; i >= 0; i--) {
       if (code & (1L << i))
         this->transmit(protocol.one);
       else
         this->transmit(protocol.zero);
     }
-    this->transmit(protocol.syncFactor);
   }
 
   // Disable transmit after sending (i.e., for inverted protocols)


### PR DESCRIPTION

![syncBack](https://user-images.githubusercontent.com/899106/122677870-37633600-d21f-11eb-9ac0-91f10a514a2d.png)
It is quite possible I totally misunderstood how to properly use this library, but I suspect there was a mistake there: the sync bits were not sent on the first repetition of the data and were appended at the end of the packet. It probably still worked as long as repeat >1 and that there is not interference.

See on the attached file (captured with `gqrx`) on the top line is the command I am trying to duplicate and on the bottom the output from `rc-switch`. Once I made the change linked here, the shapes matched.