### PR TITLE
support for longer pulses, as delayMicroseconds can only wait 16383us

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -536,9 +536,11 @@ void RCSwitch::transmit(HighLow pulses) {
   uint8_t secondLogicLevel = (this->protocol.invertedSignal) ? HIGH : LOW;
   
   digitalWrite(this->nTransmitterPin, firstLogicLevel);
-  delayMicroseconds( this->protocol.pulseLength * pulses.high);
+  delay((this->protocol.pulseLength * pulses.high)/1000);
+  delayMicroseconds((this->protocol.pulseLength * pulses.high)%1000);
   digitalWrite(this->nTransmitterPin, secondLogicLevel);
-  delayMicroseconds( this->protocol.pulseLength * pulses.low);
+  delay((this->protocol.pulseLength * pulses.low)/1000);
+  delayMicroseconds((this->protocol.pulseLength * pulses.low)%1000);
 }
 
 


### PR DESCRIPTION

Hello, 

I am playing with NICE flo2 [1] remotes with M1E chip [2]

Based on the output from "receiver example" the protocol of these remotes is 11 with  pulses around 665us:
```
Decimal: 1161 (12Bit) Binary: 010010001001 Tri-State: not applicable PulseLength: 665 microseconds Protocol: 11
Raw data: 23916,636,716,1312,1396,636,720,1304,720,1304,1404,628,720,1304,720,1304,716,1300,1400,632,720,1304,716,1304,1400,

Decimal: 1162 (12Bit) Binary: 010010001010 Tri-State: not applicable PulseLength: 664 microseconds Protocol: 11
Raw data: 23912,636,716,1312,1404,628,720,1304,720,1304,1396,636,720,1304,720,1300,720,1300,1400,632,724,1296,1400,632,720,
```
unfortunately, "send example" did not work for me because the protocol requires 35x665us pulse which is more than 16383(max for delayMicrosecons() [3]).

so I simply split delays for milliseconds delay and microseconds delay using basic calculations, which works for me.

generated codes using send example with simple mySwitch.setProtocol(11,665);


```
Decimal: 1161 (12Bit) Binary: 010010001001 Tri-State: not applicable PulseLength: 670 microseconds Protocol: 11
Raw data: 24140,680,748,1344,1420,680,744,1348,748,1356,1412,684,752,1344,748,1344,748,1344,1416,676,748,1340,748,1344,1416,

Decimal: 1162 (12Bit) Binary: 010010001010 Tri-State: not applicable PulseLength: 670 microseconds Protocol: 11
Raw data: 24144,688,736,1356,1408,688,740,1356,740,1356,1408,680,748,1348,744,1348,748,1344,1416,676,744,1344,1420,680,744,
```
[1] https://www.remotecontrol-express.com/remote+NICE+:+FLO2+%28SWITCHS%29
[2] https://datasheetspdf.com/pdf-file/1404207/MOSDESIGN/M1E/1
[3] https://www.arduino.cc/reference/en/language/functions/time/delaymicroseconds/