### PR TITLE
Add one protocol for Dooya Cover Motor

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -90,7 +90,8 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
   { 200, { 130, 7 }, {  16, 7 }, { 16,  3 }, true},      // protocol 9 Conrad RS-200 TX
   { 365, { 18,  1 }, {  3,  1 }, {  1,  3 }, true },     // protocol 10 (1ByOne Doorbell)
   { 270, { 36,  1 }, {  1,  2 }, {  2,  1 }, true },     // protocol 11 (HT12E)
-  { 320, { 36,  1 }, {  1,  2 }, {  2,  1 }, true }      // protocol 12 (SM5212)
+  { 320, { 36,  1 }, {  1,  2 }, {  2,  1 }, true },     // protocol 12 (SM5212)
+  { 350, { 14,  4 }, {  1,  2 }, {  2,  1 }, false }     // protocol 13 (Dooya Cover)
 };
 
 enum {


### PR DESCRIPTION
Add one protocol for Dooya Cover Motor remote control . 
Dooya Cover Motor is widely used. It will be more easiler to get and send code by rc_switch.