### PR TITLE
Setter function to send sync factor before the code word

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -508,13 +508,13 @@ void RCSwitch::send(unsigned long code, unsigned int length) {
 #endif
 
   for (int nRepeat = 0; nRepeat < nRepeatTransmit; nRepeat++) {
+    this->transmit(protocol.syncFactor);
     for (int i = length-1; i >= 0; i--) {
       if (code & (1L << i))
         this->transmit(protocol.one);
       else
         this->transmit(protocol.zero);
     }
-    this->transmit(protocol.syncFactor);
   }
 
   // Disable transmit after sending (i.e., for inverted protocols)

--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -114,6 +114,7 @@ RCSwitch::RCSwitch() {
   this->nTransmitterPin = -1;
   this->setRepeatTransmit(10);
   this->setProtocol(1);
+  this->setSyncFactorFirst(false);
   #if not defined( RCSwitchDisableReceiving )
   this->nReceiverInterrupt = -1;
   this->setReceiveTolerance(60);
@@ -157,6 +158,14 @@ void RCSwitch::setProtocol(int nProtocol, int nPulseLength) {
 void RCSwitch::setPulseLength(int nPulseLength) {
   this->protocol.pulseLength = nPulseLength;
 }
+
+/**
+  * Sets sync factor to be sent first, before the code word
+  */
+void RCSwitch::setSyncFactorFirst(bool syncFactor) {
+  this->syncFactorFirst = syncFactor;
+}
+
 
 /**
  * Sets Repeat Transmits
@@ -508,13 +517,22 @@ void RCSwitch::send(unsigned long code, unsigned int length) {
 #endif
 
   for (int nRepeat = 0; nRepeat < nRepeatTransmit; nRepeat++) {
-    this->transmit(protocol.syncFactor);
+    
+    if (this->syncFactorFirst) {
+      this->transmit(protocol.syncFactor);
+    }
+    
     for (int i = length-1; i >= 0; i--) {
       if (code & (1L << i))
         this->transmit(protocol.one);
       else
         this->transmit(protocol.zero);
     }
+
+    if (!this->syncFactorFirst) {
+      this->transmit(protocol.syncFactor);
+    }
+
   }
 
   // Disable transmit after sending (i.e., for inverted protocols)

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -97,6 +97,7 @@ class RCSwitch {
     void enableTransmit(int nTransmitterPin);
     void disableTransmit();
     void setPulseLength(int nPulseLength);
+    void setSyncFactorFirst(bool syncFactorFirst);
     void setRepeatTransmit(int nRepeatTransmit);
     #if not defined( RCSwitchDisableReceiving )
     void setReceiveTolerance(int nPercent);

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -162,6 +162,7 @@ class RCSwitch {
     #endif
     int nTransmitterPin;
     int nRepeatTransmit;
+    bool syncFactorFirst = false;
     
     Protocol protocol;
 


### PR DESCRIPTION
This PR implements a setter function to toggle wether we want to send sync pulse before or after the data stream. This is based on several requests (and my need to have that as well).

https://github.com/sui77/rc-switch/issues/385
https://github.com/sui77/rc-switch/issues/414
https://github.com/sui77/rc-switch/issues/414

https://github.com/sui77/rc-switch/pull/428
https://github.com/sui77/rc-switch/pull/86